### PR TITLE
Add support for passing jwksUri array

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Library to retrieve RSA public keys from a JWKS endpoint",
   "main": "lib/index.js",
   "dependencies": {
+    "async": "^2.1.2",
     "debug": "^2.2.0",
     "limiter": "^1.1.0",
     "lru-memoizer": "^1.6.0",


### PR DESCRIPTION
Hi,

This PR extends the `jwksUri` option to receive both string (single URI) and array of strings (multiple URIs).

This is useful when we need to verify one token against multiple key sources (for example projects using Amazon Cognito with multiple User Pools).

Feedbacks are welcome & appreciated!
