### PR TITLE
Fix TypeScript function capitalization

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,9 +31,9 @@ declare module 'jwks-rsa' {
       handleSigningKeyError?(err: Error, cb: (err: Error) => void): any;
     }
 
-    function ExpressJwtSecret(options: JwksRsa.Options): ExpressJwt.SecretCallback;
+    function expressJwtSecret(options: JwksRsa.Options): ExpressJwt.SecretCallback;
 
-    function HapiJwt2Key(options: JwksRsa.Options): (name: string, scheme: string, options?: any) => void;
+    function hapiJwt2Key(options: JwksRsa.Options): (name: string, scheme: string, options?: any) => void;
 
     class ArgumentError extends Error {
       constructor(message: string);


### PR DESCRIPTION
Currently these are uncallable in TS - both these functions should be lowercase.