### PR TITLE
added option to set a default kid for framework integrations

### DIFF
--- a/examples/express-demo/README.md
+++ b/examples/express-demo/README.md
@@ -17,7 +17,8 @@ app.use(jwt({
     cache: true,
     rateLimit: true,
     jwksRequestsPerMinute: 5,
-    jwksUri: `https://my-authz-server/.well-known/jwks.json`
+    jwksUri: `https://my-authz-server/.well-known/jwks.json`,
+    defaultJwtKid: `default-kid-abc123`//optional kid to default to if JWT header didn't include a kid
   }),
 
   // Validate the audience and the issuer.

--- a/examples/hapi-demo/README.md
+++ b/examples/hapi-demo/README.md
@@ -26,7 +26,8 @@ server.register(jwt, (err) => {
       cache: true,
       rateLimit: true,
       jwksRequestsPerMinute: 2,
-      jwksUri: 'https://my-authz-server/.well-known/jwks.json'
+      jwksUri: 'https://my-authz-server/.well-known/jwks.json',
+      defaultJwtKid: `default-kid-abc123` //optional kid to default to if JWT header didn't include a kid
     }),
 
     // Your own logic to validate the user.

--- a/examples/koa-demo/README.md
+++ b/examples/koa-demo/README.md
@@ -18,7 +18,8 @@ app.use(jwt({
     cache: true,
     rateLimit: true,
     jwksRequestsPerMinute: 2,
-    jwksUri: `${jwksHost}/.well-known/jwks.json`
+    jwksUri: `${jwksHost}/.well-known/jwks.json`,
+    defaultJwtKid: `default-kid-abc123`, //optional kid to default to if JWT header didn't include a kid
   }),
   audience,
   issuer,

--- a/src/integrations/express.js
+++ b/src/integrations/express.js
@@ -27,7 +27,7 @@ module.exports.expressJwtSecret = (options) => {
       return cb(null, null);
     }
 
-    client.getSigningKey(header.kid, (err, key) => {
+    client.getSigningKey(header.kid || options.defaultJwtKid, (err, key) => {
       if (err) {
         return onError(err, (newError) => cb(newError, null));
       }

--- a/src/integrations/hapi.js
+++ b/src/integrations/hapi.js
@@ -32,7 +32,7 @@ module.exports.hapiJwt2Key = (options) => {
       return cb(null, null, null);
     }
 
-    client.getSigningKey(decoded.header.kid, (err, key) => {
+    client.getSigningKey(decoded.header.kid || options.defaultJwtKid, (err, key) => {
       if (err) {
         return onError(err, (newError) => cb(newError, null, null));
       }

--- a/src/integrations/koa.js
+++ b/src/integrations/koa.js
@@ -9,7 +9,7 @@ module.exports.koaJwtSecret = (options = {}) => {
 
   const client = new JwksClient(options);
 
-  return function secretProvider({ alg, kid } = {}) {
+  return function secretProvider({ alg, kid = options.defaultJwtKid } = {}) {
 
     return new Promise((resolve, reject) => {
 


### PR DESCRIPTION
since the JWT spec has `kid` as an optional header field, I thought its might be good to set a optional `kid` to default to for verifying against the token's JWKS.

thoughts?