### PR TITLE
Use promises if cb isn't passed in

### DIFF
--- a/src/integrations/hapi.js
+++ b/src/integrations/hapi.js
@@ -24,21 +24,40 @@ module.exports.hapiJwt2Key = (options) => {
   return function secretProvider(decoded, cb) {
     // We cannot find a signing certificate if there is no header (no kid).
     if (!decoded || !decoded.header) {
-      return cb(null, null, null);
+      if (cb) {
+        return cb(null, null, null);
+      }
+      return Promise.resolve();
     }
 
     // Only RS256 is supported.
     if (decoded.header.alg !== 'RS256') {
-      return cb(null, null, null);
+      if (cb) {
+        return cb(null, null, null);
+      }
+      return Promise.resolve();
     }
 
-    client.getSigningKey(decoded.header.kid, (err, key) => {
-      if (err) {
-        return onError(err, (newError) => cb(newError, null, null));
-      }
+    if (cb) {
+      return client.getSigningKey(decoded.header.kid, (err, key) => {
+        if (err) {
+          return onError(err, (newError) => cb(newError, null, null));
+        }
 
-      // Provide the key.
-      return cb(null, key.publicKey || key.rsaPublicKey, key);
+        // Provide the key.
+        return cb(null, key.publicKey || key.rsaPublicKey, key);
+      });
+    }
+
+    return new Promise((resolve, reject) => {
+      client.getSigningKey(decoded.header.kid, (err, key) => {
+        if (err) {
+          return onError(err, reject);
+        }
+
+        // Provide the key.
+        return resolve({ key: key.publicKey || key.rsaPublicKey });
+      });
     });
   };
 };


### PR DESCRIPTION
- supports hapi v17

I'm a little out of my depth on this one but this fixed the issue I was having when using https://github.com/salzhrani/hapi-auth-jwt2/tree/v-17 with hapi v17 where I was getting the following error: 

```
180223/145803.900, [error] message: Cannot match against 'undefined' or 'null'., stack: TypeError: Cannot match against 'undefined' or 'null'.
    at Object.authenticate (/Users/clarkie/code/tojs/server/node_modules/hapi-auth-jwt2/lib/index.js:126:115)
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:228:7)
```

Let me know if I need to do any more to this to handle the other cases. 