### PR TITLE
Adding support for hapi 17.x.x

### DIFF
--- a/examples/hapi-demo/README.md
+++ b/examples/hapi-demo/README.md
@@ -22,6 +22,11 @@ server.register(jwt, (err) => {
     complete: true,
 
     // Dynamically provide a signing key based on the kid in the header and the singing keys provided by the JWKS endpoint.
+
+    /* If you're using Hapi 17.x.x you have to use version 8.x.x of hapi-auth-jwt2
+      (https://github.com/dwyl/hapi-auth-jwt2#compatibility) and use the promise based version jwksRsa.hapiJwt2KeyAsync instead of jwksRsa.hapiJwt2Key
+    */
+
     key: jwksRsa.hapiJwt2Key({
       cache: true,
       rateLimit: true,

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,6 +35,8 @@ declare module 'jwks-rsa' {
 
     function hapiJwt2Key(options: JwksRsa.Options): (name: string, scheme: string, options?: any) => void;
 
+    function hapiJwt2KeyAsync(options: JwksRsa.Options): (name: string, scheme: string, options?: any) => void;
+
     function koaJwtSecret(options: JwksRsa.Options): (name: string, scheme: string, options?: any) => void;
 
     class ArgumentError extends Error {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import { JwksClient } from './JwksClient';
 
 import * as errors from './errors';
-import { hapiJwt2Key } from './integrations/hapi';
+import { hapiJwt2Key, hapiJwt2KeyAsync } from './integrations/hapi';
 import { expressJwtSecret } from './integrations/express';
 import { koaJwtSecret } from './integrations/koa';
 
@@ -16,4 +16,5 @@ module.exports.SigningKeyNotFoundError = errors.SigningKeyNotFoundError;
 
 module.exports.expressJwtSecret = expressJwtSecret;
 module.exports.hapiJwt2Key = hapiJwt2Key;
+module.exports.hapiJwt2KeyAsync = hapiJwt2KeyAsync;
 module.exports.koaJwtSecret = koaJwtSecret;

--- a/src/integrations/hapi.js
+++ b/src/integrations/hapi.js
@@ -13,6 +13,23 @@ const handleSigningKeyError = (err, cb) => {
   }
 };
 
+/**
+ * Call hapiJwt2Key as a Promise
+ * @param {object} options 
+ * @returns {Promise}
+ */
+module.exports.hapiJwt2KeyAsync = (options) => {
+  const secretProvider = module.exports.hapiJwt2Key(options);
+  return function(decoded) {
+    return new Promise((resolve, reject) => {
+      const cb = (err, key) => {
+        (!key || err) ? reject(err) : resolve({ key });
+      };
+      secretProvider(decoded, cb);
+    });
+  };
+}; 
+
 module.exports.hapiJwt2Key = (options) => {
   if (options === null || options === undefined) {
     throw new ArgumentError('An options object must be provided when initializing expressJwtSecret');


### PR DESCRIPTION
Add support for hapi-auth-jwt2 8.x.x using Hapi 17.x.x  as documented on 
[https://github.com/dwyl/hapi-auth-jwt2#compatibility](https://github.com/dwyl/hapi-auth-jwt2#compatibility)

Introduced a new promised based method  **hapiJwt2KeyAsync**