### PR TITLE
Allow adding custom headers when fetching a JWKS document.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 declare module 'jwks-rsa' {
 
   import * as ExpressJwt from "express-jwt";
+  import { OutgoingHttpHeaders } from "http";
 
   function JwksRsa(options: JwksRsa.Options): JwksRsa.JwksClient;
 
@@ -28,6 +29,7 @@ declare module 'jwks-rsa' {
       cacheMaxAge?: number;
       jwksRequestsPerMinute?: number;
       strictSsl?: boolean;
+      headers?: OutgoingHttpHeaders;
       handleSigningKeyError?(err: Error, cb: (err: Error) => void): any;
     }
 

--- a/src/JwksClient.js
+++ b/src/JwksClient.js
@@ -10,7 +10,7 @@ import { cacheSigningKey, rateLimitSigningKey } from './wrappers';
 
 export class JwksClient {
   constructor(options) {
-    this.options = { rateLimit: false, cache: false, strictSsl: true, ...options };
+    this.options = { rateLimit: false, cache: false, strictSsl: true, headers: {}, ...options };
     this.logger = debug('jwks');
 
     // Initialize wrappers.
@@ -24,7 +24,7 @@ export class JwksClient {
 
   getKeys(cb) {
     this.logger(`Fetching keys from '${this.options.jwksUri}'`);
-    request({ json: true, uri: this.options.jwksUri, strictSSL: this.options.strictSsl }, (err, res) => {
+    request({ json: true, uri: this.options.jwksUri, strictSSL: this.options.strictSsl, headers: this.options.headers }, (err, res) => {
       if (err || res.statusCode < 200 || res.statusCode >= 300) {
         this.logger('Failure:', res && res.body || err);
         if (res) {


### PR DESCRIPTION
We have an environment where we need to provide custom headers to HTTP GET a JWKS document (more specifically, an `l5d-dtab:` routing header for the [linkerd](https://linkerd.io/) service mesh).  This PR adds an optional `headers:` field to the `JwksClient` configuration, which allows us to do:

```javascript
import jwksRsa from 'jwks-rsa';

jwksRsa.expressJwtSecret({
  jwksUri: 'http://service.name/jwks.json',
  headers: { 'l5d-dtab': '/foo=>/bar' }
});
```

The headers field is optional and the default is to add no additional headers; this should not introduce any compatibility issues for existing code.