### PR TITLE
Allow JWT to not contain a "kid" value

### DIFF
--- a/src/JwksClient.js
+++ b/src/JwksClient.js
@@ -70,12 +70,9 @@ export class JwksClient {
           if(key.kty !== 'RSA') {
             return false;
           }
-          if(!key.kid) {
-            return false;
-          }
           if(key.hasOwnProperty('use') && key.use !== 'sig') {
             return false;
-          }  
+          }
           return ((key.x5c && key.x5c.length) || (key.n && key.e));
         })
         .map(key => {
@@ -111,7 +108,13 @@ export class JwksClient {
         return cb(err);
       }
 
-      const key = keys.find(k => k.kid === kid);
+      const kidDefined = kid !== undefined && kid !== null;
+      if (!kidDefined && keys.length > 1) {
+        this.logger('No KID specified and JWKS endpoint returned more than 1 key');
+        return cb(new SigningKeyNotFoundError('No KID specified and JWKS endpoint returned more than 1 key'));
+      }
+
+      const key = keys.find(k => !kidDefined || k.kid === kid);
       if (key) {
         return cb(null, key);
       } else {

--- a/tests/express.es5.tests.js
+++ b/tests/express.es5.tests.js
@@ -164,7 +164,7 @@ describe('expressJwtSecret', () => {
         })
       });
 
-      jwksEndpoint('http://localhost', [ { pub: publicKey, kid: '123' } ]);
+      jwksEndpoint('http://localhost', [ { pub: publicKey } ]);
 
       const token = createToken(privateKey, undefined, { sub: 'john' });
       const req = { headers: { authorization: `Bearer ${token}` } };

--- a/tests/koa.tests.js
+++ b/tests/koa.tests.js
@@ -73,7 +73,7 @@ describe('koaJwtSecret', () => {
       });
   });
 
-  it('should not provide a key if token is RS256 and no KID was provided', (done) => {
+  it('should not provide a key if JWKS endpoint returned multiple keys and no KID was provided', (done) => {
     const app = new Koa();
     app.use(koaJwt({
       debug: true,
@@ -83,14 +83,14 @@ describe('koaJwtSecret', () => {
     }));
 
     const token = createToken(privateKey, null, { sub: 'john' });
-    jwksEndpoint('http://localhost', [ { pub: publicKey, kid: '123' } ]);
+    jwksEndpoint('http://localhost', [ { pub: publicKey, kid: '123' }, { pub: publicKey, kid: '456' } ]);
 
     request(app.listen())
       .get('/')
       .set('Authorization', `Bearer ${ token }`)
       .expect(401)
       .end((err, res) => {
-        expect(res.text).to.equal('Unable to find a signing key that matches \'null\'');
+        expect(res.text).to.equal('No KID specified and JWKS endpoint returned more than 1 key');
         done();
       });
   });
@@ -184,6 +184,32 @@ describe('koaJwtSecret', () => {
     });
 
     const token = createToken(privateKey, '123', { sub: 'john' });
+    jwksEndpoint('http://localhost', [ { pub: publicKey, kid: '123' } ]);
+
+    request(app.listen())
+      .get('/')
+      .set('Authorization', `Bearer ${ token }`)
+      .expect(200)
+      .end((err, res) => {
+        expect(res.body.sub).to.equal('john');
+        done();
+      });
+  });
+
+  it('should work if the JWKS endpoint returns a single key and no KID is provided', (done) => {
+    const app = new Koa();
+    app.use(koaJwt({
+      debug: true,
+      secret: jwksRsa.koaJwtSecret({
+        jwksUri: 'http://localhost/.well-known/jwks.json'
+      })
+    }));
+    app.use((ctx) => {
+      ctx.body = ctx.state.user;
+      ctx.status = 200;
+    });
+
+    const token = createToken(privateKey, undefined, { sub: 'john' });
     jwksEndpoint('http://localhost', [ { pub: publicKey, kid: '123' } ]);
 
     request(app.listen())

--- a/tests/koa.tests.js
+++ b/tests/koa.tests.js
@@ -210,7 +210,7 @@ describe('koaJwtSecret', () => {
     });
 
     const token = createToken(privateKey, undefined, { sub: 'john' });
-    jwksEndpoint('http://localhost', [ { pub: publicKey, kid: '123' } ]);
+    jwksEndpoint('http://localhost', [ { pub: publicKey } ]);
 
     request(app.listen())
       .get('/')

--- a/tests/passport.tests.js
+++ b/tests/passport.tests.js
@@ -115,7 +115,7 @@ describe('passportJwtSecret', () => {
       });
   });
 
-  it('should not provide a key if token is RS256 and no KID was provided', done => {
+  it('should not provide a key if JWKS endpoint returned multiple keys and no KID was provided', done => {
     const app = new Express();
     passport.use(
       new JwtStrategy(
@@ -144,7 +144,7 @@ describe('passportJwtSecret', () => {
     );
 
     const token = createToken(privateKey, null, { sub: 'john' });
-    jwksEndpoint('http://localhost', [ { pub: publicKey, kid: '123' } ]);
+    jwksEndpoint('http://localhost', [ { pub: publicKey, kid: '123' }, { pub: publicKey, kid: '456' } ]);
 
     request(app.listen())
       .get('/')


### PR DESCRIPTION
Allow JWT to not contain a "kid" value when the JWKS endpoint only returns a single key.

The spec marks this claim as optional.