### PR TITLE
Throw errors when hapi integration fails

### DIFF
--- a/src/integrations/hapi.js
+++ b/src/integrations/hapi.js
@@ -41,12 +41,12 @@ module.exports.hapiJwt2Key = (options) => {
   return function secretProvider(decoded, cb) {
     // We cannot find a signing certificate if there is no header (no kid).
     if (!decoded || !decoded.header) {
-      return cb(null, null, null);
+      return cb(new Error('Invalid JWT header'), null, null);
     }
 
     // Only RS256 is supported.
     if (decoded.header.alg !== 'RS256') {
-      return cb(null, null, null);
+      return cb(new Error('An invalid signing algorithm was specified, node-jwks-rsa supports only RS256', null, null);
     }
 
     client.getSigningKey(decoded.header.kid, (err, key) => {

--- a/src/integrations/hapi.js
+++ b/src/integrations/hapi.js
@@ -46,7 +46,7 @@ module.exports.hapiJwt2Key = (options) => {
 
     // Only RS256 is supported.
     if (decoded.header.alg !== 'RS256') {
-      return cb(new Error('An invalid signing algorithm was specified, node-jwks-rsa supports only RS256', null, null);
+      return cb(new Error('An invalid signing algorithm was specified, node-jwks-rsa supports only RS256'), null, null);
     }
 
     client.getSigningKey(decoded.header.kid, (err, key) => {


### PR DESCRIPTION
At the moment the hapi integration fails by sending `null` as the error object, which results in this cryptic an unhelpful error from hapi:

```
[start] Debug: internal, implementation, error
    Error: Cannot throw non-error object
    at module.exports.internals.Manager.execute (.../node_modules/hapi/lib/toolkit.js:44:33)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

I suspect the most often case for this happening is ours, when an HS256-signed JWT is being sent. This pull request adds a couple of error messages so that the user gets some information about what is actually going wrong. I kind of guessed about what they say, my domain knowledge here is not great. Feel free to make them more informative.
