### PR TITLE
Add option to pass prefetched json content

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ const jwksClient = require('jwks-rsa');
 
 const client = jwksClient({
   strictSsl: true, // Default value
-  jwksUri: 'https://sandrino.auth0.com/.well-known/jwks.json'
+  jwksUri: 'https://sandrino.auth0.com/.well-known/jwks.json' // alternatively you can pass prefetched json with `jwksContent`
 });
 
 const kid = 'RkI5MjI5OUY5ODc1N0Q4QzM0OUYzNkVGMTJDOUEzQkFCOTU3NjE2Rg';

--- a/src/JwksClient.js
+++ b/src/JwksClient.js
@@ -1,7 +1,6 @@
 import debug from 'debug';
 import request from 'request';
 
-import ArgumentError from './errors/ArgumentError';
 import JwksError from './errors/JwksError';
 import SigningKeyNotFoundError from './errors/SigningKeyNotFoundError';
 
@@ -23,6 +22,9 @@ export class JwksClient {
   }
 
   getKeys(cb) {
+    if (this.options.jwksContent) {
+      return cb(null, this.options.jwksContent.keys);
+    }
     this.logger(`Fetching keys from '${this.options.jwksUri}'`);
     request({ json: true, uri: this.options.jwksUri, strictSSL: this.options.strictSsl }, (err, res) => {
       if (err || res.statusCode < 200 || res.statusCode >= 300) {

--- a/tests/jwksClient.tests.js
+++ b/tests/jwksClient.tests.js
@@ -64,6 +64,37 @@ describe('JwksClient', () => {
         done();
       });
     });
+
+    it('can work with prefetched key set json', function() {
+      const client = new JwksClient({
+        jwksContent: {
+          keys: [
+            {
+              alg: 'RS256',
+              kty: 'RSA',
+              use: 'sig',
+              x5c: [
+                'pk1'
+              ],
+              kid: 'ABC'
+            },
+            {
+              alg: 'RS256',
+              kty: 'RSA',
+              use: 'sig',
+              x5c: [],
+              kid: '123'
+            }
+          ]
+        }
+      });
+      client.getKeys((err, keys) => {
+        expect(err).to.be.null;
+        expect(keys).not.to.be.null;
+        expect(keys.length).to.equal(2);
+        expect(keys[1].kid).to.equal('123');
+      });
+    });
   });
 
   describe('#getSigningKeys', () => {


### PR DESCRIPTION
Work around for #29 

Usage example:

```javascript
const httpism = require('httpism')

...
const jwksContent = await httpism.get('https://xyz.eu.auth0.com/.well-known/jwks.json')
const client = jwksClient({
  jwksContent
})
client.getSigningKey(header.kid, function(err, key) {
  ...
```