### PR TITLE
webkey property specifying 'use' is optional

### DIFF
--- a/src/JwksClient.js
+++ b/src/JwksClient.js
@@ -49,7 +49,7 @@ export class JwksClient {
       }
 
       const signingKeys = keys
-        .filter(key => (key.use === 'sig' || key.use === null) && key.kty === 'RSA' && key.kid && ((key.x5c && key.x5c.length) || (key.n && key.e)))
+        .filter(key => (key.use === 'sig' || !key.use) && key.kty === 'RSA' && key.kid && ((key.x5c && key.x5c.length) || (key.n && key.e)))
         .map(key => {
           if (key.x5c && key.x5c.length) {
             return { kid: key.kid, nbf: key.nbf, publicKey: certToPEM(key.x5c[0]) };

--- a/src/JwksClient.js
+++ b/src/JwksClient.js
@@ -49,7 +49,7 @@ export class JwksClient {
       }
 
       const signingKeys = keys
-        .filter(key => key.use === 'sig' && key.kty === 'RSA' && key.kid && ((key.x5c && key.x5c.length) || (key.n && key.e)))
+        .filter(key => (key.use === 'sig' || key.use === null) && key.kty === 'RSA' && key.kid && ((key.x5c && key.x5c.length) || (key.n && key.e)))
         .map(key => {
           if (key.x5c && key.x5c.length) {
             return { kid: key.kid, nbf: key.nbf, publicKey: certToPEM(key.x5c[0]) };


### PR DESCRIPTION
I encountered a provider (`OneLogin`) that did not specify `"use":"sig"` for their webkey, which causes the `jwksClient` to crash.

It seems that `use` is optional according to the discussion in this PR: https://github.com/IdentityModel/IdentityModel.OidcClient2/pull/77

This PR will allow a web key to be used for signatures when `use` is not specified.
