### PR TITLE
Fix typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,92 +1,96 @@
-declare module 'jwks-rsa' {
-  import * as ExpressJwt from 'express-jwt';
+import { SecretCallbackLong } from 'express-jwt';
 
-  function JwksRsa(options: JwksRsa.ClientOptions): JwksRsa.JwksClient;
+declare function JwksRsa(options: JwksRsa.ClientOptions): JwksRsa.JwksClient;
 
-  namespace JwksRsa {
-    class JwksClient {
-      constructor(options: ClientOptions);
+declare namespace JwksRsa {
+  class JwksClient {
+    constructor(options: ClientOptions);
 
-      getKeys(cb: (err: Error | null, keys: unknown) => void): void;
-      getSigningKeys(cb: (err: Error | null, keys: SigningKey[]) => void): void;
-      getSigningKey: (kid: string, cb: (err: Error | null, key: SigningKey) => void) => void;
-    }
+    getKeys(cb: (err: Error | null, keys: unknown) => void): void;
 
-    interface ClientOptions {
-      jwksUri: string;
-      rateLimit?: boolean;
-      cache?: boolean;
-      cacheMaxEntries?: number;
-      cacheMaxAge?: number;
-      jwksRequestsPerMinute?: number;
-      strictSsl?: boolean;
-    }
+    getSigningKeys(cb: (err: Error | null, keys: SigningKey[]) => void): void;
 
-    interface CertSigningKey {
-      kid: string;
-      nbf: string;
-      publicKey: string;
-    }
-
-    interface RsaSigningKey {
-      kid: string;
-      nbf: string;
-      rsaPublicKey: string;
-    }
-
-    type SigningKey = CertSigningKey | RsaSigningKey;
-
-    function expressJwtSecret(options: ExpressJwtOptions): ExpressJwt.SecretCallbackLong;
-
-    interface ExpressJwtOptions extends ClientOptions {
-      handleSigningKeyError?: (err: Error | null, cb: (err: Error | null) => void) => void;
-    }
-
-    function hapiJwt2Key(options: HapiJwtOptions): (decodedToken: DecodedToken, cb: HapiCallback) => void;
-
-    interface HapiJwtOptions extends ClientOptions {
-      handleSigningKeyError?: (err: Error | null, cb: HapiCallback) => void;
-    }
-
-    type HapiCallback = (err: Error | null, publicKey: string, signingKey: SigningKey) => void;
-
-    interface DecodedToken {
-      header: TokenHeader;
-    }
-
-    interface TokenHeader {
-      alg: string;
-      kid: string;
-    }
-
-    function hapiJwt2KeyAsync(options: HapiJwtOptions): (decodedToken: DecodedToken) => Promise<{ key: SigningKey }>;
-
-    function koaJwtSecret(options: KoaJwtOptions): (header: TokenHeader) => Promise<string>;
-
-    interface KoaJwtOptions extends ClientOptions {
-      handleSigningKeyError?(err: Error | null): Promise<void>;
-    }
-
-    class ArgumentError extends Error {
-      name: 'ArgumentError';
-      constructor(message: string);
-    }
-
-    class JwksError extends Error {
-      name: 'JwksError';
-      constructor(message: string);
-    }
-
-    class JwksRateLimitError extends Error {
-      name: 'JwksRateLimitError';
-      constructor(message: string);
-    }
-
-    class SigningKeyNotFoundError extends Error {
-      name: 'SigningKeyNotFoundError';
-      constructor(message: string);
-    }
+    getSigningKey: (kid: string, cb: (err: Error | null, key: SigningKey) => void) => void;
   }
 
-  export = JwksRsa;
+  interface ClientOptions {
+    jwksUri: string;
+    rateLimit?: boolean;
+    cache?: boolean;
+    cacheMaxEntries?: number;
+    cacheMaxAge?: number;
+    jwksRequestsPerMinute?: number;
+    strictSsl?: boolean;
+  }
+
+  interface CertSigningKey {
+    kid: string;
+    nbf: string;
+    publicKey: string;
+  }
+
+  interface RsaSigningKey {
+    kid: string;
+    nbf: string;
+    rsaPublicKey: string;
+  }
+
+  type SigningKey = CertSigningKey | RsaSigningKey;
+
+  function expressJwtSecret(options: ExpressJwtOptions): SecretCallbackLong;
+
+  interface ExpressJwtOptions extends ClientOptions {
+    handleSigningKeyError?: (err: Error | null, cb: (err: Error | null) => void) => void;
+  }
+
+  function hapiJwt2Key(options: HapiJwtOptions): (decodedToken: DecodedToken, cb: HapiCallback) => void;
+
+  interface HapiJwtOptions extends ClientOptions {
+    handleSigningKeyError?: (err: Error | null, cb: HapiCallback) => void;
+  }
+
+  type HapiCallback = (err: Error | null, publicKey: string, signingKey: SigningKey) => void;
+
+  interface DecodedToken {
+    header: TokenHeader;
+  }
+
+  interface TokenHeader {
+    alg: string;
+    kid: string;
+  }
+
+  function hapiJwt2KeyAsync(options: HapiJwtOptions): (decodedToken: DecodedToken) => Promise<{ key: SigningKey }>;
+
+  function koaJwtSecret(options: KoaJwtOptions): (header: TokenHeader) => Promise<string>;
+
+  interface KoaJwtOptions extends ClientOptions {
+    handleSigningKeyError?(err: Error | null): Promise<void>;
+  }
+
+  class ArgumentError extends Error {
+    name: 'ArgumentError';
+
+    constructor(message: string);
+  }
+
+  class JwksError extends Error {
+    name: 'JwksError';
+
+    constructor(message: string);
+  }
+
+  class JwksRateLimitError extends Error {
+    name: 'JwksRateLimitError';
+
+    constructor(message: string);
+  }
+
+  class SigningKeyNotFoundError extends Error {
+    name: 'SigningKeyNotFoundError';
+
+    constructor(message: string);
+  }
 }
+
+export = JwksRsa;

--- a/index.d.ts
+++ b/index.d.ts
@@ -65,7 +65,7 @@ declare namespace JwksRsa {
     kid: string;
   }
 
-  function hapiJwt2KeyAsync(options: HapiJwtOptions): (decodedToken: DecodedToken) => Promise<{ key: SigningKey }>;
+  function hapiJwt2KeyAsync(options: HapiJwtOptions): (decodedToken: DecodedToken) => Promise<{ key: string }>;
 
   function koaJwtSecret(options: KoaJwtOptions): (header: TokenHeader) => Promise<string>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ declare module 'jwks-rsa' {
 
       getKeys(cb: (err: Error | null, keys: unknown) => void): void;
       getSigningKeys(cb: (err: Error | null, keys: SigningKey[]) => void): void;
-      getSigningKey(kid: string, cb: (err: Error | null, key: SigningKey) => void): void;
+      getSigningKey: (kid: string, cb: (err: Error | null, key: SigningKey) => void) => void;
     }
 
     interface ClientOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,9 +7,7 @@ declare namespace JwksRsa {
     constructor(options: ClientOptions);
 
     getKeys(cb: (err: Error | null, keys: unknown) => void): void;
-
     getSigningKeys(cb: (err: Error | null, keys: SigningKey[]) => void): void;
-
     getSigningKey: (kid: string, cb: (err: Error | null, key: SigningKey) => void) => void;
   }
 
@@ -70,25 +68,21 @@ declare namespace JwksRsa {
 
   class ArgumentError extends Error {
     name: 'ArgumentError';
-
     constructor(message: string);
   }
 
   class JwksError extends Error {
     name: 'JwksError';
-
     constructor(message: string);
   }
 
   class JwksRateLimitError extends Error {
     name: 'JwksRateLimitError';
-
     constructor(message: string);
   }
 
   class SigningKeyNotFoundError extends Error {
     name: 'SigningKeyNotFoundError';
-
     constructor(message: string);
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,7 +31,7 @@ declare module 'jwks-rsa' {
     interface RsaSigningKey {
       kid: string;
       nbf: string;
-      rsaPublicKey;
+      rsaPublicKey: string;
     }
 
     type SigningKey = CertSigningKey | RsaSigningKey;
@@ -68,27 +68,23 @@ declare module 'jwks-rsa' {
     }
 
     class ArgumentError extends Error {
-      constructor(message: string);
-
       name: 'ArgumentError';
+      constructor(message: string);
     }
 
     class JwksError extends Error {
-      constructor(message: string);
-
       name: 'JwksError';
+      constructor(message: string);
     }
 
     class JwksRateLimitError extends Error {
-      constructor(message: string);
-
       name: 'JwksRateLimitError';
+      constructor(message: string);
     }
 
     class SigningKeyNotFoundError extends Error {
-      constructor(message: string);
-
       name: 'SigningKeyNotFoundError';
+      constructor(message: string);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "lib/index.js",
   "types": "index.d.ts",
   "dependencies": {
-    "@types/express-jwt": "0.0.34",
     "debug": "^2.2.0",
     "limiter": "^1.1.0",
     "lru-memoizer": "^1.6.0",
@@ -13,6 +12,7 @@
     "request": "^2.73.0"
   },
   "devDependencies": {
+    "@types/express-jwt": "0.0.34",
     "babel-cli": "^6.9.0",
     "babel-core": "^6.9.0",
     "babel-eslint": "^6.0.4",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "types": "index.d.ts",
   "dependencies": {
+    "@types/express-jwt": "0.0.41",
     "debug": "^2.2.0",
     "limiter": "^1.1.0",
     "lru-memoizer": "^1.6.0",
@@ -12,7 +13,6 @@
     "request": "^2.73.0"
   },
   "devDependencies": {
-    "@types/express-jwt": "0.0.34",
     "babel-cli": "^6.9.0",
     "babel-core": "^6.9.0",
     "babel-eslint": "^6.0.4",


### PR DESCRIPTION
The typescript typings are not really accurate at the moment. This fixes them. Note that jwt-express types should be listed in dependencies (as they are now) because we re-export a type from that package.

Incorporates #73, #69, #54.
Fixes #46, #28, #78, #75.