### PR TITLE
Update @types/express-jwt version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "types": "index.d.ts",
   "dependencies": {
-    "@types/express-jwt": "0.0.34",
+    "@types/express-jwt": "0.0.42",
     "debug": "^2.2.0",
     "limiter": "^1.1.0",
     "lru-memoizer": "^1.6.0",


### PR DESCRIPTION
`@types/express-jwt 0.0.34` declares the following global type for express's `req.user` object

```typescript
declare global {
    namespace Express {
        export interface Request {
            user?: any
        }
    }
}
```

Due to this - when trying to type out the req.user project in your own project the following error is thrown:

`node_modules/@types/express-jwt/index.d.ts:43:13 - error TS2717: Subsequent property declarations must have the same type.  Property 'user' must be of type '{ id: string }', but here has type 'any'`

This PR updates `@types/express-jwt` to its latest version - which no longer declares a global express type.