### PR TITLE
feat: fix: allowing the exclusion of key.use

### DIFF
--- a/src/JwksClient.js
+++ b/src/JwksClient.js
@@ -65,7 +65,7 @@ export class JwksClient {
       }
 
       const signingKeys = keys
-        .filter(key => key.kty === 'RSA' && (key.use === 'sign' || !key.use) && key.kid && ((key.x5c && key.x5c.length) || (key.n && key.e)))
+        .filter(key => key.kty === 'RSA' && (key.use === 'sig' || !key.use) && key.kid && ((key.x5c && key.x5c.length) || (key.n && key.e)))
         .map(key => {
           if (key.x5c && key.x5c.length) {
             return {

--- a/src/JwksClient.js
+++ b/src/JwksClient.js
@@ -65,7 +65,7 @@ export class JwksClient {
       }
 
       const signingKeys = keys
-        .filter(key => key.use === 'sig' && key.kty === 'RSA' && key.kid && ((key.x5c && key.x5c.length) || (key.n && key.e)))
+        .filter(key => key.kty === 'RSA' && (key.use === 'sign' || !key.use) && key.kid && ((key.x5c && key.x5c.length) || (key.n && key.e)))
         .map(key => {
           if (key.x5c && key.x5c.length) {
             return {


### PR DESCRIPTION
### Description

JWKS does allow for keys without the `use` property, and we follow this practice in our business.

An example would be a key with the following properties defined: `[ kty, kid, alg, e, n ]`

The benefit of this change will increase the compatibility of this npm package's implementation of the JWKs specification.

### References

- https://tools.ietf.org/html/rfc7517#section-4.2
- ```Use of the "use" member is OPTIONAL```

### Testing

Create a URI for a jwks.json file with an array entry in the keys property with the following properties:  `[ kty, kid, alg, e, n ]`

Sample code: 
```
const test1 = ({ kid, jwksUri }) => new Promise(resolve => {
  require('jwks-rsa')
    ({ cache: true, cacheMaxEntries: 5, jwksUri })
    .getSigningKey(kid, (err, key) => resolve(!err && (key.publicKey || key.rsaPublicKey)));
});

test1({ kid: 'xxx', jwksUri:'yyy' }).then(console.log)
```

As a result, the RSA public key will be printed to the console.
