### PR TITLE
Update lru-memoizer to 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,9 +62,9 @@
       }
     },
     "@types/body-parser": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
-      "integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.1.tgz",
+      "integrity": "sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==",
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -85,9 +85,9 @@
       }
     },
     "@types/express": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.0.tgz",
-      "integrity": "sha512-CjaMu57cjgjuZbh9DpkloeGxV45CnMGlVd+XpG7Gm9QgVrd7KFq+X4HY0vM+2v0bczS48Wg7bvnMY5TN+Xmcfw==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-VfH/XCP0QbQk5B5puLqTLEeFgR8lfCJHZJKkInZ9mkYd+u8byX0kztXEQxEk4wZXJs8HI+7km2ALXjn4YKcX9w==",
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
@@ -95,18 +95,18 @@
       }
     },
     "@types/express-jwt": {
-      "version": "0.0.41",
-      "resolved": "https://registry.npmjs.org/@types/express-jwt/-/express-jwt-0.0.41.tgz",
-      "integrity": "sha512-Ob6fScCuEGaV0nqpqE3AEsxOjGNyF4Yksx9cqyjgwxuX3rW43J05EooE4CRHcyT/dO/VTKHmK0qn9X0z3A9GIg==",
+      "version": "0.0.42",
+      "resolved": "https://registry.npmjs.org/@types/express-jwt/-/express-jwt-0.0.42.tgz",
+      "integrity": "sha512-WszgUddvM1t5dPpJ3LhWNH8kfNN8GPIBrAGxgIYXVCEGx6Bx4A036aAuf/r5WH9DIEdlmp7gHOYvSM6U87B0ag==",
       "requires": {
         "@types/express": "*",
         "@types/express-unless": "*"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.16.7",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz",
-      "integrity": "sha512-847KvL8Q1y3TtFLRTXcVakErLJQgdpFSaq+k043xefz9raEf0C7HalpSY7OW5PyjCnY8P7bPW5t/Co9qqp+USg==",
+      "version": "4.16.9",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.9.tgz",
+      "integrity": "sha512-GqpaVWR0DM8FnRUJYKlWgyARoBUAVfRIeVDZQKOttLFp5SmhhF9YFIYeTPwMd/AXfxlP7xVO2dj1fGu0Q+krKQ==",
       "requires": {
         "@types/node": "*",
         "@types/range-parser": "*"
@@ -151,9 +151,9 @@
       "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
     },
     "@types/serve-static": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
-      "integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
+      "integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
       "requires": {
         "@types/express-serve-static-core": "*",
         "@types/mime": "*"
@@ -4213,21 +4213,22 @@
         "path-exists": "^3.0.0"
       }
     },
-    "lock": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/lock/-/lock-0.1.4.tgz",
-      "integrity": "sha1-/sfervF+fDoKVeHaBCgD4l2RdF0="
-    },
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
+      "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40=",
+      "dev": true
     },
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
       "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -4335,14 +4336,12 @@
       }
     },
     "lru-memoizer": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-1.12.0.tgz",
-      "integrity": "sha1-7+ZXBsyKnMZT+A8NWm6jitlQ41I=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.0.1.tgz",
+      "integrity": "sha512-kGl+zlIqdQL24f0Q9IUSUZeSvA7nqXPFLA7suFh00v4KVqfXkZJtkPfTfXV/oQMSPfNr6VT4xGkRAUPhFnGyxQ==",
       "requires": {
-        "lock": "~0.1.2",
-        "lodash": "^4.17.4",
-        "lru-cache": "~4.0.0",
-        "very-fast-args": "^1.1.0"
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "~4.0.0"
       }
     },
     "make-error": {
@@ -6699,11 +6698,6 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
-    },
-    "very-fast-args": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/very-fast-args/-/very-fast-args-1.1.0.tgz",
-      "integrity": "sha1-4W0dH6+KbllqJGQh/ZCneWPQs5Y="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "debug": "^2.6.9",
     "jsonwebtoken": "^8.5.1",
     "limiter": "^1.1.4",
-    "lru-memoizer": "^1.12.0",
+    "lru-memoizer": "^2.0.1",
     "ms": "^2.1.1",
     "request": "^2.88.0"
   },


### PR DESCRIPTION
### Description

lru-memorizer had unused dependency on lodash being detected by snyk.io

This was removed here https://github.com/jfromaniello/lru-memoizer/commit/c2cf36d98231e370fd14ce1649478b69bec43176

### References

Raised in Github issue [#86] 

### Testing

Existing test coverage runs successfully
No change to exisiting test coverage required.

- [  ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [`x`] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [` `] All active GitHub checks for tests, formatting, and security are passing
- [` `] The correct base branch is being used, if not `master`
