### PR TITLE
Handling case when Jwk doesn't have 'use' parameter

### DIFF
--- a/src/JwksClient.js
+++ b/src/JwksClient.js
@@ -66,7 +66,7 @@ export class JwksClient {
       }
 
       const signingKeys = keys
-        .filter(key => (!key.use || key.use === 'sig') && key.kty === 'RSA' && key.kid && ((key.x5c && key.x5c.length) || (key.n && key.e)))
+        .filter(key => (!key.hasOwnProperty('use') || key.use === 'sig') && key.kty === 'RSA' && key.kid && ((key.x5c && key.x5c.length) || (key.n && key.e)))
         .map(key => {
           if (key.x5c && key.x5c.length) {
             return {

--- a/src/JwksClient.js
+++ b/src/JwksClient.js
@@ -66,7 +66,18 @@ export class JwksClient {
       }
 
       const signingKeys = keys
-        .filter(key => (!key.hasOwnProperty('use') || key.use === 'sig') && key.kty === 'RSA' && key.kid && ((key.x5c && key.x5c.length) || (key.n && key.e)))
+          .filter((key) => {
+            if(key.kty !== 'RSA'){
+              return false;
+            }
+            if(!key.kid){
+              return false;
+            }
+            if(key.hasOwnProperty('use') && key.use !== 'sig'){
+              return false;
+            }  
+            return ((key.x5c && key.x5c.length) || (key.n && key.e));
+        })
         .map(key => {
           if (key.x5c && key.x5c.length) {
             return {

--- a/src/JwksClient.js
+++ b/src/JwksClient.js
@@ -66,7 +66,7 @@ export class JwksClient {
       }
 
       const signingKeys = keys
-        .filter(key => key.use === 'sig' && key.kty === 'RSA' && key.kid && ((key.x5c && key.x5c.length) || (key.n && key.e)))
+        .filter(key => (!key.use || key.use === 'sig') && key.kty === 'RSA' && key.kid && ((key.x5c && key.x5c.length) || (key.n && key.e)))
         .map(key => {
           if (key.x5c && key.x5c.length) {
             return {

--- a/tests/jwksClient.tests.js
+++ b/tests/jwksClient.tests.js
@@ -282,14 +282,13 @@ describe("JwksClient", () => {
             {
               kid: "IdTokenSigningKeyContainer.v3",
               nbf: 1459289287,
-              use: "",
               kty: "RSA",
               e: "AQAB",
               n:
                 "s4W7xjkQZP3OwG7PfRgcYKn8eRYXHiz1iK503fS-K2FZo-Ublwwa2xFZWpsUU_jtoVCwIkaqZuo6xoKtlMYXXvfVHGuKBHEBVn8b8x_57BQWz1d0KdrNXxuMvtFe6RzMqiMqzqZrzae4UqVCkYqcR9gQx66Ehq7hPmCxJCkg7ajo7fu6E7dPd34KH2HSYRsaaEA_BcKTeb9H1XE_qEKjog68wUU9Ekfl3FBIRN-1Ah_BoktGFoXyi_jt0-L0-gKcL1BLmUlGzMusvRbjI_0-qj-mc0utGdRjY-xIN2yBj8vl4DODO-wMwfp-cqZbCd9TENyHaTb8iA27s-73L3ExOQ"
             },
             {
-              kid: "IdTokenSigningKeyContainer.v3",
+              kid: "IdTokenSigningKeyContainer.v4",
               nbf: 1459289287,
               use: "enc",
               kty: "RSA",

--- a/tests/jwksClient.tests.js
+++ b/tests/jwksClient.tests.js
@@ -278,6 +278,14 @@ describe("JwksClient", () => {
               e: "AQAB",
               n:
                 "s4W7xjkQZP3OwG7PfRgcYKn8eRYXHiz1iK503fS-K2FZo-Ublwwa2xFZWpsUU_jtoVCwIkaqZuo6xoKtlMYXXvfVHGuKBHEBVn8b8x_57BQWz1d0KdrNXxuMvtFe6RzMqiMqzqZrzae4UqVCkYqcR9gQx66Ehq7hPmCxJCkg7ajo7fu6E7dPd34KH2HSYRsaaEA_BcKTeb9H1XE_qEKjog68wUU9Ekfl3FBIRN-1Ah_BoktGFoXyi_jt0-L0-gKcL1BLmUlGzMusvRbjI_0-qj-mc0utGdRjY-xIN2yBj8vl4DODO-wMwfp-cqZbCd9TENyHaTb8iA27s-73L3ExOQ"
+            },
+            {
+              "kid": "85b539b0f0c8429b8fabcd6526401444",
+              "kty": "RSA",
+              "use": "",
+              "alg": "",
+              "n": "iY2WDVmdhraQwnsHzkV8pMuuhaA75jYd5faUEN6ARESsK3tJFioky1HSpEbzpb5iVqCK45C-p6jAZzI9Ci1J9G46t2svoXao_eFGddL6uYzkkd_jFrmk8GXG9lnBnqeoOCPvhOjznAJmEFC4HHx5X3o5uqNnBAWBW0Th65bu5ktLOIy29A4gIwYH7vGdTiUSGx-YkXic5LSePs7zNlOtkULSAcHPxgIzW8GTnvaYep41qYvwotHiBdWX9zf4Q5uZOGSfEO-P01ph_iaTUY2kmUrLRzsq4ztChWBK0kHxJLm64CJP46MYFUdaGjLcAFOyMRJr6hzmxrIKFeQzjmVDIQ",
+              "e": "AQAB"
             }
           ]
         });
@@ -289,12 +297,13 @@ describe("JwksClient", () => {
       client.getSigningKeys((err, keys) => {
         expect(err).to.be.null;
         expect(keys).not.to.be.null;
-        expect(keys.length).to.equal(2);
+        expect(keys.length).to.equal(3);
         expect(keys[0].rsaPublicKey).not.to.be.null;
         expect(keys[0].kid).to.equal("IdTokenSigningKeyContainer");
         expect(keys[1].kid).to.equal("IdTokenSigningKeyContainer.v2");
         expect(keys[1].rsaPublicKey).not.to.be.null;
         expect(keys[1].nbf).to.equal(1459289287);
+        expect(keys[2].rsaPublicKey).not.to.be.null;
         done();
       });
     });

--- a/tests/jwksClient.tests.js
+++ b/tests/jwksClient.tests.js
@@ -280,13 +280,23 @@ describe("JwksClient", () => {
                 "s4W7xjkQZP3OwG7PfRgcYKn8eRYXHiz1iK503fS-K2FZo-Ublwwa2xFZWpsUU_jtoVCwIkaqZuo6xoKtlMYXXvfVHGuKBHEBVn8b8x_57BQWz1d0KdrNXxuMvtFe6RzMqiMqzqZrzae4UqVCkYqcR9gQx66Ehq7hPmCxJCkg7ajo7fu6E7dPd34KH2HSYRsaaEA_BcKTeb9H1XE_qEKjog68wUU9Ekfl3FBIRN-1Ah_BoktGFoXyi_jt0-L0-gKcL1BLmUlGzMusvRbjI_0-qj-mc0utGdRjY-xIN2yBj8vl4DODO-wMwfp-cqZbCd9TENyHaTb8iA27s-73L3ExOQ"
             },
             {
-              "kid": "85b539b0f0c8429b8fabcd6526401444",
-              "kty": "RSA",
-              "use": "",
-              "alg": "",
-              "n": "iY2WDVmdhraQwnsHzkV8pMuuhaA75jYd5faUEN6ARESsK3tJFioky1HSpEbzpb5iVqCK45C-p6jAZzI9Ci1J9G46t2svoXao_eFGddL6uYzkkd_jFrmk8GXG9lnBnqeoOCPvhOjznAJmEFC4HHx5X3o5uqNnBAWBW0Th65bu5ktLOIy29A4gIwYH7vGdTiUSGx-YkXic5LSePs7zNlOtkULSAcHPxgIzW8GTnvaYep41qYvwotHiBdWX9zf4Q5uZOGSfEO-P01ph_iaTUY2kmUrLRzsq4ztChWBK0kHxJLm64CJP46MYFUdaGjLcAFOyMRJr6hzmxrIKFeQzjmVDIQ",
-              "e": "AQAB"
-            }
+              kid: "IdTokenSigningKeyContainer.v3",
+              nbf: 1459289287,
+              use: "",
+              kty: "RSA",
+              e: "AQAB",
+              n:
+                "s4W7xjkQZP3OwG7PfRgcYKn8eRYXHiz1iK503fS-K2FZo-Ublwwa2xFZWpsUU_jtoVCwIkaqZuo6xoKtlMYXXvfVHGuKBHEBVn8b8x_57BQWz1d0KdrNXxuMvtFe6RzMqiMqzqZrzae4UqVCkYqcR9gQx66Ehq7hPmCxJCkg7ajo7fu6E7dPd34KH2HSYRsaaEA_BcKTeb9H1XE_qEKjog68wUU9Ekfl3FBIRN-1Ah_BoktGFoXyi_jt0-L0-gKcL1BLmUlGzMusvRbjI_0-qj-mc0utGdRjY-xIN2yBj8vl4DODO-wMwfp-cqZbCd9TENyHaTb8iA27s-73L3ExOQ"
+            },
+            {
+              kid: "IdTokenSigningKeyContainer.v3",
+              nbf: 1459289287,
+              use: "enc",
+              kty: "RSA",
+              e: "AQAB",
+              n:
+                "s4W7xjkQZP3OwG7PfRgcYKn8eRYXHiz1iK503fS-K2FZo-Ublwwa2xFZWpsUU_jtoVCwIkaqZuo6xoKtlMYXXvfVHGuKBHEBVn8b8x_57BQWz1d0KdrNXxuMvtFe6RzMqiMqzqZrzae4UqVCkYqcR9gQx66Ehq7hPmCxJCkg7ajo7fu6E7dPd34KH2HSYRsaaEA_BcKTeb9H1XE_qEKjog68wUU9Ekfl3FBIRN-1Ah_BoktGFoXyi_jt0-L0-gKcL1BLmUlGzMusvRbjI_0-qj-mc0utGdRjY-xIN2yBj8vl4DODO-wMwfp-cqZbCd9TENyHaTb8iA27s-73L3ExOQ"
+            },
           ]
         });
 


### PR DESCRIPTION
#113 
# Description

Updated the code to handle the case when 'use' parameter in jwk key is not present on is not having any value. As per spec, https://tools.ietf.org/html/rfc7517#section-4.2 
> Use of the "use" member is OPTIONAL, unless the application  requires its presence.

Added a check to check for presence first, if key is present and having non blank value then compare if value is 'sig' as per spec. 

### References

This PR is submitted in response to Open issue #24 

### Testing
Updated test cases to include 2 test cases
-  value of 'use' is blank (Should pass)
-  value of 'use' is 'enc' (Should fail)

Command `npm run test` can be used to test the implementation

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
