### PR TITLE
Collapse CertSigningKey and RsaSigningKey into single SigningKey interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,11 +26,17 @@ declare namespace JwksRsa {
     requestHeaders?: Headers;
   }
 
-  interface CertSigningKey {
+  interface SigningKey {
     kid: string;
     nbf: string;
-    publicKey: string;
+    publicKey?: string;
+    rsaPublicKey?: string;
   }
+
+  // In 1.6.1 and earlier, we had separate CertSigningKey and RsaSigningKey types.
+  // This maintains backwards compatibilty.
+  type CertSigningKey = SigningKey;
+  type RsaSigningKey = SigningKey;
 
   interface AgentOptions {
     [key: string]: string;
@@ -48,14 +54,6 @@ declare namespace JwksRsa {
     requestAgentOptions?: AgentOptions;
     handleSigningKeyError?(err: Error, cb: (err: Error) => void): any;
   }
-
-  interface RsaSigningKey {
-    kid: string;
-    nbf: string;
-    rsaPublicKey: string;
-  }
-
-  type SigningKey = CertSigningKey | RsaSigningKey;
 
   function expressJwtSecret(options: ExpressJwtOptions): SecretCallbackLong;
 


### PR DESCRIPTION
## Description

I tried using node-jwks-rsa in a TypeScript project for the first time, and I found it challenging to do because of the way `SigningKey`, `CertSigningKey`, and `RsaSigningKey` types are defined.

Disclaimer: I'm a TypeScript newbie, so I'm not confident about either the problem I found or the solution I'm proposing. If I'm off-base, I'd be very happy to be pointed in a better direction.

The problem I see stems from the fact that the basic usage example from the README doesn't work in TypeScript:

```
client.getSigningKey(kid, (err, key) => {
  const signingKey = key.publicKey || key.rsaPublicKey;
```

The TypeScript compiler screams at me because the type of `key` (`SingingKey`) doesn't include `publicKey` or `rsaPublicKey`. How can I fix this?

Well, maybe I should know in advance which type of `SingingKey` to expect. Then, I could declare it when I invoke `getSigningKey`:

```
client.getSigningKey(kid, (err, key: RsaSigningKey) => {
  const signingKey = key.rsaPublicKey;
```

That makes TypeScript happy, but haven't I just made my code more brittle? What happens if it goes out and fetches the JWKS endpoint, and the key with KID I asked for turns out not to be an RSA key?

Or, if I want to keep the dynamic behaviour I had before, I can get TypeScript to be quiet like this:

```
client.getSigningKey(kid, (err, key: any) => {
  const signingKey = key.publicKey || key.rsaPublicKey;
```

But now I've lost all benefit of TypeScript in this code. If I accidentally type `key.rsPublicKey`, it won't catch the error for me.

So, thinking about it, it seems to me that the type definitions were unnecessarily strict. The difference between `CertSigningKey` and `RsaSigningKey` is dynamic, not static. You can't tell just from looking at the code which one to expect, so maybe we're outside of the realm of types?

My idea is to simplify back down to one type definition:

```
interface SigningKey {
  kid: string;
  nbf: string;
  publicKey?: string;
  rsaPublicKey?: string;
}
```

And then everything just works.

Note that this PR does maintain the existing `CertSigningKey` and `RsaSigningKey` simply as aliases for `SigningKey`, just to avoid breaking any clients that already reference them.

### Testing

Since this is a minor tweak to just the type definitions and the implementation is unchanged, I didn't write any additional tests. The existing tests all continue to pass without change.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`