### PR TITLE
Modify Cache Defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,15 @@ Integrations are also provided with:
 
 ### Caching
 
-In order to prevent a call to be made each time a signing key needs to be retrieved you can also configure a cache as follows. If a signing key matching the `kid` is found, this will be cached and the next time this `kid` is requested the signing key will be served from the cache instead of calling back to the JWKS endpoint.
+By default, signing key verification results are cached in order to prevent excessive HTTP requests to the JWKS endpoint. If a signing key matching the `kid` is found, this will be cached and the next time this `kid` is requested the signing key will be served from the cache.  The caching behavior can be configured as seen below:
 
 ```js
 const jwksClient = require('jwks-rsa');
 
 const client = jwksClient({
-  cache: true,
+  cache: true, // Default Value
   cacheMaxEntries: 5, // Default value
-  cacheMaxAge: ms('10h'), // Default value
+  cacheMaxAge: ms('10m'), // Default value
   jwksUri: 'https://sandrino.auth0.com/.well-known/jwks.json'
 });
 
@@ -67,7 +67,6 @@ Even if caching is enabled the library will call the JWKS endpoint if the `kid` 
 const jwksClient = require('jwks-rsa');
 
 const client = jwksClient({
-  cache: true,
   rateLimit: true,
   jwksRequestsPerMinute: 10, // Default value
   jwksUri: 'https://sandrino.auth0.com/.well-known/jwks.json'

--- a/src/JwksClient.js
+++ b/src/JwksClient.js
@@ -18,7 +18,7 @@ export class JwksClient {
   constructor(options) {
     this.options = {
       rateLimit: false,
-      cache: false,
+      cache: true,
       strictSsl: true,
       ...options
     };

--- a/src/wrappers/cache.js
+++ b/src/wrappers/cache.js
@@ -2,7 +2,7 @@ import ms from 'ms';
 import debug from 'debug';
 import memoizer from 'lru-memoizer';
 
-export default function(client, { cacheMaxEntries = 5, cacheMaxAge = ms('10h') } = options) {
+export default function(client, { cacheMaxEntries = 5, cacheMaxAge = ms('10m') } = options) {
   const logger = debug('jwks');
   const getSigningKey = client.getSigningKey;
 

--- a/tests/cache.tests.js
+++ b/tests/cache.tests.js
@@ -11,49 +11,44 @@ describe('JwksClient (cache)', () => {
     nock.cleanAll();
   });
 
-  describe('#getSigningKeys', () => {
-    it('should cache requests', (done) => {
-      nock(jwksHost)
+  describe('#getSigningKey', () => {
+    describe('should cache requests per kid', () => {
+      let client;
+
+      before((done) => {
+        nock(jwksHost)
         .get('/.well-known/jwks.json')
         .reply(200, x5cSingle);
 
-      const client = new JwksClient({
-        cache: true,
-        jwksUri: `${jwksHost}/.well-known/jwks.json`
-      });
+        client = new JwksClient({
+          cache: true,
+          jwksUri: `${jwksHost}/.well-known/jwks.json`
+        });
 
-      client.getSigningKey('NkFCNEE1NDFDNTQ5RTQ5OTE1QzRBMjYyMzY0NEJCQTJBMjJBQkZCMA', (err, key) => {
-        expect(key.kid).to.equal('NkFCNEE1NDFDNTQ5RTQ5OTE1QzRBMjYyMzY0NEJCQTJBMjJBQkZCMA');
-        nock.cleanAll();
-
+        // Cache the Key
         client.getSigningKey('NkFCNEE1NDFDNTQ5RTQ5OTE1QzRBMjYyMzY0NEJCQTJBMjJBQkZCMA', (err, key) => {
           expect(key.kid).to.equal('NkFCNEE1NDFDNTQ5RTQ5OTE1QzRBMjYyMzY0NEJCQTJBMjJBQkZCMA');
+
+          // Stop the JWKS server
+          nock.cleanAll();
           done();
         });
-      });
-    });
+      })
 
-    it('should cache requests per kid', (done) => {
-      nock(jwksHost)
-        .get('/.well-known/jwks.json')
-        .reply(200, x5cSingle);
-
-      const client = new JwksClient({
-        cache: true,
-        jwksUri: `${jwksHost}/.well-known/jwks.json`
-      });
-
-      client.getSigningKey('NkFCNEE1NDFDNTQ5RTQ5OTE1QzRBMjYyMzY0NEJCQTJBMjJBQkZCMA', (err, key) => {
-        expect(key.kid).to.equal('NkFCNEE1NDFDNTQ5RTQ5OTE1QzRBMjYyMzY0NEJCQTJBMjJBQkZCMA');
-        nock.cleanAll();
-
-        // This second call should fail because we "stopped the server" and this key was not cached.
+      it('should ignore the cache when the KID isnt cached and make a requst', (done) => {
         client.getSigningKey('12345', (err) => {
           expect(err).not.to.be.null;
           expect(err.code).to.equal('ENOTFOUND');
           done();
         });
-      });
+      })
+
+      it('should fetch the key from the cache', (done) => {
+        client.getSigningKey('NkFCNEE1NDFDNTQ5RTQ5OTE1QzRBMjYyMzY0NEJCQTJBMjJBQkZCMA', (err, key) => {
+          expect(key.kid).to.equal('NkFCNEE1NDFDNTQ5RTQ5OTE1QzRBMjYyMzY0NEJCQTJBMjJBQkZCMA');
+          done();
+        });
+      })
     });
   });
 });

--- a/tests/rateLimit.tests.js
+++ b/tests/rateLimit.tests.js
@@ -14,6 +14,7 @@ describe('JwksClient (cache)', () => {
   describe('#getSigningKeys', () => {
     it('should prevent too many requests', (done) => {
       const client = new JwksClient({
+        cache: false,
         rateLimit: true,
         jwksRequestsPerMinute: 2,
         jwksUri: `${jwksHost}/.well-known/jwks.json`


### PR DESCRIPTION
### Description
In order to allow for better expiration of keys after a signing key rotation the following changes have been made to the cache:

- enables cache by default
- changes cache time from 10h to 10m
- updated tests to reflect the intent of the cache

### Testing

Updated the tests to more properly reflect the caching mechanism.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
