### PR TITLE
Add proxy option to jwksClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ const client = jwksClient({
   strictSsl: true, // Default value
   jwksUri: 'https://sandrino.auth0.com/.well-known/jwks.json',
   requestHeaders: {}, // Optional
-  requestAgentOptions: {} // Optional
+  requestAgentOptions: {}, // Optional
+  proxy: '[protocol]://[username]:[pass]@[address]:[port]', // Optional
 });
 
 const kid = 'RkI5MjI5OUY5ODc1N0Q4QzM0OUYzNkVGMTJDOUEzQkFCOTU3NjE2Rg';

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,7 @@ declare namespace JwksRsa {
     cacheMaxEntries?: number;
     cacheMaxAge?: number;
     jwksRequestsPerMinute?: number;
+    proxy?: string;
     strictSsl?: boolean;
     requestHeaders?: Headers;
   }

--- a/src/JwksClient.js
+++ b/src/JwksClient.js
@@ -40,7 +40,8 @@ export class JwksClient {
       uri: this.options.jwksUri,
       strictSSL: this.options.strictSsl,
       headers: this.options.requestHeaders,
-      agentOptions: this.options.requestAgentOptions
+      agentOptions: this.options.requestAgentOptions,
+      proxy: this.options.proxy,
     }, (err, res) => {
       if (err || res.statusCode < 200 || res.statusCode >= 300) {
         this.logger('Failure:', res && res.body || err);

--- a/tests/jwksClient.tests.js
+++ b/tests/jwksClient.tests.js
@@ -184,35 +184,11 @@ describe("JwksClient", () => {
       });
     });
 
-    it("should add a proxy", done => {
-      nock(jwksHost)
-        .get("/.well-known/jwks.json")
-        .reply(function(uri, requestBody) {
-          expect(this.req.headers).not.to.be.null;
-          expect(this.req.headers["user-agent"]).to.be.equal("My-bot");
-          expect(Object.keys(this.req.headers).length).to.be.equal(3);
-          return (
-            200,
-            {
-              keys: [
-                {
-                  alg: "RS256",
-                  kty: "RSA",
-                  use: "sig",
-                  x5c: ["pk1"],
-                  kid: "ABC"
-                },
-                {
-                  alg: "RS256",
-                  kty: "RSA",
-                  use: "sig",
-                  x5c: [],
-                  kid: "123"
-                }
-              ]
-            }
-          );
-        });
+    it("should use a proxy if specified", done => {
+      const expectedError = { message: 'expectedError' };
+      nock(`http://${proxy}`)
+        .get(() => true)
+        .replyWithError(expectedError);
   
       const client = new JwksClient({
         jwksUri: `${jwksHost}/.well-known/jwks.json`,
@@ -222,7 +198,8 @@ describe("JwksClient", () => {
         proxy: `http://username:password@${proxy}`,
       });
   
-      client.getKeys((err, keys) => {
+      client.getKeys((err) => {
+        expect(err).to.equal(expectedError);
         done();
       });
     });


### PR DESCRIPTION
### Description

I added an optional parameter to jwksClient to be able to use the proxy of the request module, in order to fetch the JWKs keys through a proxy.

### References

https://github.com/request/request#proxies

### Testing

Run `npm run test`, I added a little test for the proxy. To manually test the package, you can create a client with a proxy, and run it

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
