### PR TITLE
Send the explicit commit SHA to Codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,4 +31,4 @@ jobs:
       - run:
           name: Upload Coverage
           when: on_success
-          command: bash <(curl -s https://codecov.io/bash)
+          command: bash <(curl -s https://codecov.io/bash) -Z -C $CIRCLE_SHA1


### PR DESCRIPTION
This PR makes the coverage reporting command work when a GH rebase has occurred

See the latest build failed with:

```
HTTP 400
Commit sha does not match Circle build.
```