### PR TITLE
Fix #139 strictSsl: false option being ignored

### DIFF
--- a/src/wrappers/request.js
+++ b/src/wrappers/request.js
@@ -21,9 +21,9 @@ export default function(options, cb) {
     };
   } 
 
-  if (options.agentOptions || options.strictSSL) {
+  if (options.agentOptions || options.strictSSL != undefined) {
     const agentOptions = {
-      ...(options.strictSSL) && { rejectUnauthorized: options.strictSSL },
+      ...(options.strictSSL != undefined) && { rejectUnauthorized: options.strictSSL },
       ...options.agentOptions
     };
     requestOptions.httpAgent = new http.Agent(agentOptions);

--- a/tests/request.tests.js
+++ b/tests/request.tests.js
@@ -1,0 +1,46 @@
+import axios from 'axios';
+import { expect } from 'chai';
+
+const originalAxiosRequest = axios.request;
+const mockedAxiosRequest = (options) => {
+  return Promise.resolve(options);
+};
+axios.request = mockedAxiosRequest;
+
+import request from '../src/wrappers/request';
+
+describe('Request wrapper tests', () => {
+  
+  const uri = 'https://foo/bar';
+
+  after(() => {
+    axios.request = originalAxiosRequest;
+  });
+
+  describe('default export', () => {
+    describe('should pass through strictSSL option properly', () => {
+      it('should create agentOptions if strictSSL === true', (done) => {
+        request({ uri, strictSSL: true }, (err, options) => {
+          expect(options.httpsAgent).to.be.defined;
+          expect(options.httpsAgent.options.rejectUnauthorized).to.be.true;
+          done(err);
+        });
+      });
+
+      it('should create agentOptions if strictSSL === false', (done) => {
+        request({ uri, strictSSL: false }, (err, options) => {
+          expect(options.httpsAgent).to.be.defined;
+          expect(options.httpsAgent.options.rejectUnauthorized).to.be.false;
+          done(err);
+        });
+      });
+
+      it('should not create agentOptions if strictSSL === undefined', (done) => {
+        request({ uri }, (err, options) => {
+          expect(options.httpsAgent).to.be.undefined;
+          done(err);
+        });
+      });
+    });
+  });
+});

--- a/tests/request.tests.js
+++ b/tests/request.tests.js
@@ -1,17 +1,18 @@
 import axios from 'axios';
 import { expect } from 'chai';
 
-const originalAxiosRequest = axios.request;
-const mockedAxiosRequest = (options) => {
-  return Promise.resolve(options);
-};
-axios.request = mockedAxiosRequest;
-
 import request from '../src/wrappers/request';
 
 describe('Request wrapper tests', () => {
   
   const uri = 'https://foo/bar';
+  const originalAxiosRequest = axios.request;
+  const mockedAxiosRequest = (options) => {
+    return Promise.resolve(options);
+  };
+  before(() => {
+    axios.request = mockedAxiosRequest;
+  });
 
   after(() => {
     axios.request = originalAxiosRequest;


### PR DESCRIPTION
### Description

Fixed a bug, when passing in `strictSsl: false` option, it was ignored because of bad boolean logic handling in the request wrapper.

### References

fixes #139 

### Testing

Unit tested locally.

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
