### PR TITLE
Use axios url parameter instead of baseURL

### DIFF
--- a/src/wrappers/request.js
+++ b/src/wrappers/request.js
@@ -5,7 +5,7 @@ import { request } from 'axios';
 
 export default function(options, cb) {
   const requestOptions = {
-    baseURL: options.uri,
+    url: options.uri,
     headers: options.headers,
     timeout: options.timeout
   };


### PR DESCRIPTION
### Description

This changes the axios request parameters to use `url` instead of `baseURL`. `baseURL` should only be used in combination with `url`, otherwise it should only be `url`.

This caused an error for me when working with Axios Mock Adapter since it expected a `url` to exist. I've created a PR for that particular library, but this might cause issues elsewhere.

### References

- https://github.com/ctimmerm/axios-mock-adapter/pull/274

### Testing

The existing tests already cover this

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
