### PR TITLE
Update Buffer initialization to non-deprecated method

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -33,8 +33,8 @@ function encodeLengthHex(n) {
  * Source: http://stackoverflow.com/questions/18835132/xml-to-pem-in-node-js
  */
 export function rsaPublicKeyToPEM(modulusB64, exponentB64) {
-  const modulus = new Buffer(modulusB64, 'base64');
-  const exponent = new Buffer(exponentB64, 'base64');
+  const modulus = Buffer.from(modulusB64, 'base64');
+  const exponent = Buffer.from(exponentB64, 'base64');
   const modulusHex = prepadSigned(modulus.toString('hex'));
   const exponentHex = prepadSigned(exponent.toString('hex'));
   const modlen = modulusHex.length / 2;
@@ -47,7 +47,7 @@ export function rsaPublicKeyToPEM(modulusB64, exponentB64) {
     '02' + encodedModlen + modulusHex +
     '02' + encodedExplen + exponentHex;
 
-  const der = new Buffer(encodedPubkey, 'hex')
+  const der = Buffer.from(encodedPubkey, 'hex')
     .toString('base64');
 
   let pem = '-----BEGIN RSA PUBLIC KEY-----\n';


### PR DESCRIPTION
### Description

The purpose of this pull request is to update the Buffer initializations within the utility.js file away from the deprecated method (calling the Buffer constructor) , and instead call Buffer.from().

Calling the Buffer constructor has been deprecated and results in the following message during runtime, as detailed [here](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/):
>The Buffer() and new Buffer() constructors are not recommended for use due to security and usability concerns. Please use the new Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() construction methods instead.




### References

Issue #150 

### Testing

No tests have been added, although the test suite was re-ran and all tests are still passing.

### Checklist

- [no] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [yes] All active GitHub checks for tests, formatting, and security are passing
- [n/a (using master)] The correct base branch is being used, if not `master`
