### PR TITLE
Add promisified methods to JwksClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ client.getSigningKey(kid, (err, key) => {
 });
 ```
 
+> Note that all methods on the `JwksClient` have asynchronous equivalents, where the promisified name is suffixed with `Async`, e.g., `client.getSigningKeyAsync(kid).then(key => { /* ... */ })`;
+
 Integrations are also provided with:
 
  - [express/express-jwt](examples/express-demo)

--- a/src/JwksClient.js
+++ b/src/JwksClient.js
@@ -123,4 +123,37 @@ export class JwksClient {
       }
     });
   }
+
+  getKeysAsync = () => {
+    return new Promise((resolve, reject) => {
+      this.getKeys(function(err, keys) {
+        if (err) {
+          reject(err);
+        }
+        resolve(keys);
+      })
+    });
+  }
+
+  getSigningKeysAsync = () => {
+    return new Promise((resolve, reject) => {
+      this.getSigningKeys(function(err, keys) {
+        if (err) {
+          reject(err);
+        }
+        resolve(keys);
+      })
+    });
+  }
+
+  getSigningKeyAsync = (kid) => {
+    return new Promise((resolve, reject) => {
+      this.getSigningKey(kid, function(err, key) {
+        if (err) {
+          reject(err);
+        }
+        resolve(key);
+      })
+    });
+  }
 }

--- a/src/JwksClient.js
+++ b/src/JwksClient.js
@@ -124,36 +124,18 @@ export class JwksClient {
     });
   }
 
-  getKeysAsync = () => {
-    return new Promise((resolve, reject) => {
-      this.getKeys(function(err, keys) {
-        if (err) {
-          reject(err);
-        }
-        resolve(keys);
-      })
-    });
-  }
-
-  getSigningKeysAsync = () => {
-    return new Promise((resolve, reject) => {
-      this.getSigningKeys(function(err, keys) {
-        if (err) {
-          reject(err);
-        }
-        resolve(keys);
-      })
-    });
-  }
-
-  getSigningKeyAsync = (kid) => {
-    return new Promise((resolve, reject) => {
-      this.getSigningKey(kid, function(err, key) {
-        if (err) {
-          reject(err);
-        }
-        resolve(key);
-      })
-    });
-  }
+  getKeysAsync = promisifyIt(this.getKeys, this);
+  getSigningKeysAsync = promisifyIt(this.getSigningKeys, this);
+  getSigningKeyAsync = promisifyIt(this.getSigningKey, this);
 }
+
+const promisifyIt = (fn, ctx) => (...args) => {
+  return new Promise((resolve, reject) => {
+    fn.call(ctx, ...args, (err, data) => {
+      if (err) {
+        reject(err)
+      }
+      resolve(data)
+    });
+  });
+};

--- a/src/JwksClient.js
+++ b/src/JwksClient.js
@@ -124,8 +124,63 @@ export class JwksClient {
     });
   }
 
+  /**
+   * Get all keys. Use this if you prefer to use Promises or async/await.
+   *
+   * @example
+   * client.getKeysAsync()
+   *   .then(keys => { console.log(`Returned {keys.length} keys`); })
+   *   .catch(err => { console.error('Error getting keys', err); });
+   *
+   * // async/await:
+   * try {
+   *  let keys = await client.getKeysAsync();
+   * } catch (err) {
+   *  console.error('Error getting keys', err);
+   * }
+   *
+   * @return {Promise}
+   */
   getKeysAsync = promisifyIt(this.getKeys, this);
+
+  /**
+   * Get all signing keys. Use this if you prefer to use Promises or async/await.
+   *
+   * @example
+   * client.getSigningKeysAsync()
+   *   .then(keys => { console.log(`Returned {keys.length} signing keys`); })
+   *   .catch(err => { console.error('Error getting keys', err); });
+   *
+   * // async/await:
+   * try {
+   *  let keys = await client.getSigningKeysAsync();
+   * } catch (err) {
+   *  console.error('Error getting signing keys', err);
+   * }
+   *
+   * @return {Promise}
+   */
   getSigningKeysAsync = promisifyIt(this.getSigningKeys, this);
+
+  /**
+   * Get a signing key for a specified key ID (kid). Use this if you prefer to use Promises or async/await.
+   *
+   * @example
+   * client.getSigningKeyId('someKid')
+   *   .then(key => { console.log(`Signing key returned is {key.getPublicKey()}`); })
+   *   .catch(err => { console.error('Error getting signing key', err); });
+   *
+   * // async/await:
+   * try {
+   *  let key = await client.getSigningKeyAsync('someKid');
+   * } catch (err) {
+   *  console.error('Error getting signing key', err);
+   * }
+   *
+   * @param {String} kid   The Key ID of the signing key to retrieve.
+   *
+   * @return {Promise}
+   */
   getSigningKeyAsync = promisifyIt(this.getSigningKey, this);
 }
 

--- a/src/JwksClient.js
+++ b/src/JwksClient.js
@@ -188,9 +188,9 @@ const promisifyIt = (fn, ctx) => (...args) => {
   return new Promise((resolve, reject) => {
     fn.call(ctx, ...args, (err, data) => {
       if (err) {
-        reject(err)
+        reject(err);
       }
-      resolve(data)
+      resolve(data);
     });
   });
 };

--- a/tests/jwksClient.tests.js
+++ b/tests/jwksClient.tests.js
@@ -205,6 +205,63 @@ describe('JwksClient', () => {
     });
   });
   
+  describe('#getKeysAsync', () => {
+    it('should handle errors when async', done => {
+      nock(jwksHost)
+        .get('/.well-known/jwks.json')
+        .reply(500, 'Unknown Server Error');
+
+      const client = new JwksClient({
+        jwksUri: `${jwksHost}/.well-known/jwks.json`
+      });
+
+      client.getKeysAsync()
+        .catch(err => {
+          expect(err).not.to.be.null;
+          expect(err.message).to.equal('Unknown Server Error');
+          done();
+        });
+    });
+
+    it('should return keys when async', function(done) {
+      nock(jwksHost)
+        .get('/.well-known/jwks.json')
+        .reply(200, {
+          keys: [
+            {
+              alg: 'RS256',
+              kty: 'RSA',
+              use: 'sig',
+              x5c: [ 'pk1' ],
+              kid: 'ABC'
+            },
+            {
+              alg: 'RS256',
+              kty: 'RSA',
+              use: 'sig',
+              x5c: [],
+              kid: '123'
+            }
+          ]
+        });
+
+      const client = new JwksClient({
+        jwksUri: `${jwksHost}/.well-known/jwks.json`
+      });
+
+      client.getKeysAsync()
+        .then(keys => {
+          expect(keys).not.to.be.null;
+          expect(keys.length).to.equal(2);
+          expect(keys[1].kid).to.equal('123');
+          done();
+        })
+        .catch(err => {
+          done(err);
+        });
+    });
+  });
+
   describe('#getSigningKeys', () => {
     it('should handle errors', done => {
       nock(jwksHost)
@@ -440,6 +497,62 @@ describe('JwksClient', () => {
     });
   });
 
+  describe('#getSigningKeysAsync', () => {
+    it('should handle errors when async', done => {
+      nock(jwksHost)
+        .get('/.well-known/jwks.json')
+        .reply(500, 'Unknown Server Error');
+
+      const client = new JwksClient({
+        jwksUri: `${jwksHost}/.well-known/jwks.json`
+      });
+
+      client.getSigningKeysAsync()
+        .catch(err => {
+          expect(err).not.to.be.null;
+          expect(err.message).to.equal('Unknown Server Error');
+          done();
+        });
+    });
+
+    it('should return signing keys to promise success handler when async', done => {
+      nock(jwksHost)
+        .get('/.well-known/jwks.json')
+        .reply(200, {
+          keys: [
+            {
+              kid: 'IdTokenSigningKeyContainer',
+              use: 'sig',
+              kty: 'RSA',
+              e: 'AQAB',
+              n:
+                'tLDZVZ2Eq_DFwNp24yeSq_Ha0MYbYOJs_WXIgVxQGabu5cZ9561OUtYWdB6xXXZLaZxFG02P5U2rC_CT1r0lPfC_KHYrviJ5Y_Ekif7iFV_1omLAiRksQziwA1i-hND32N5kxwEGNmZViVjWMBZ43wbIdWss4IMhrJy1WNQ07Fqp1Ee6o7QM1hTBve7bbkJkUAfjtC7mwIWqZdWoYIWBTZRXvhMgs_Aeb_pnDekosqDoWQ5aMklk3NvaaBBESqlRAJZUUf5WDFoJh7yRELOFF4lWJxtArTEiQPWVTX6PCs0klVPU6SRQqrtc4kKLCp1AC5EJqPYRGiEJpSz2nUhmAQ'
+            },
+            {
+              kid: 'IdTokenSigningKeyContainer.v2',
+              nbf: 1459289287,
+              use: 'sig',
+              kty: 'RSA',
+              e: 'AQAB',
+              n:
+                's4W7xjkQZP3OwG7PfRgcYKn8eRYXHiz1iK503fS-K2FZo-Ublwwa2xFZWpsUU_jtoVCwIkaqZuo6xoKtlMYXXvfVHGuKBHEBVn8b8x_57BQWz1d0KdrNXxuMvtFe6RzMqiMqzqZrzae4UqVCkYqcR9gQx66Ehq7hPmCxJCkg7ajo7fu6E7dPd34KH2HSYRsaaEA_BcKTeb9H1XE_qEKjog68wUU9Ekfl3FBIRN-1Ah_BoktGFoXyi_jt0-L0-gKcL1BLmUlGzMusvRbjI_0-qj-mc0utGdRjY-xIN2yBj8vl4DODO-wMwfp-cqZbCd9TENyHaTb8iA27s-73L3ExOQ'
+            }
+          ]
+        });
+
+      const client = new JwksClient({
+        jwksUri: `${jwksHost}/.well-known/jwks.json`
+      });
+
+      client.getSigningKeysAsync()
+        .then(keys => {
+          expect(keys).to.not.be.null;
+          expect(keys.length).to.equal(2);
+          done();
+        });
+    });
+  });
+
   describe('#getSigningKey', () => {
     it('should return error if signing key is not found', done => {
       nock(jwksHost)
@@ -456,5 +569,24 @@ describe('JwksClient', () => {
         done();
       });
     });
+  });
+
+  describe('#getSigningKeyAsync', () => {
+    it('should handle error when async', done => {
+      nock(jwksHost)
+        .get('/.well-known/jwks.json')
+        .reply(500, 'Unknown Server Error');
+
+      const client = new JwksClient({
+        jwksUri: `${jwksHost}/.well-known/jwks.json`
+      });
+
+      client.getSigningKeyAsync('')
+        .catch(err => {
+          expect(err).not.to.be.null;
+          expect(err.message).to.equal('Unknown Server Error');
+          done();
+        });
+    })
   });
 });

--- a/tests/jwksClient.tests.js
+++ b/tests/jwksClient.tests.js
@@ -587,6 +587,6 @@ describe('JwksClient', () => {
           expect(err.message).to.equal('Unknown Server Error');
           done();
         });
-    })
+    });
   });
 });


### PR DESCRIPTION
### Description

As raised in #76, this library should support methods that return Promises. This change adds new promisified equivalents for `JwksClient`, suffixed with `Async`:
- `getKeysAsync()`
- `getSigningKeysAsync()`
- `getSigningKeyAsync(kid)`

This change:
- Adds no additional dependencies
- Changes no existing APIs
- Makes no breaking changes, so can be released in a new minor version to the `1.x` version

### References

#76 

### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
