### PR TITLE
Add missing async methods to Typescript type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,8 +7,11 @@ declare namespace JwksRsa {
     constructor(options: ClientOptions);
 
     getKeys(cb: (err: Error | null, keys: unknown) => void): void;
+    getKeysAsync(): Promise<unknown>;
     getSigningKeys(cb: (err: Error | null, keys: SigningKey[]) => void): void;
-    getSigningKey: (kid: string, cb: (err: Error | null, key: SigningKey) => void) => void;
+    getSigningKeysAsync(): Promise<SigningKey[]>;
+    getSigningKey(kid: string, cb: (err: Error | null, key: SigningKey) => void): void;
+    getSigningKeyAsync(kid: string): Promise<SigningKey>;
   }
 
   interface Headers {


### PR DESCRIPTION
### Description

New "async" methods that return promises were added by #161, but the PR did not include an update to the matching Typescript type definitions. Without this update, these new methods are unusable in Typescript projects.

### References

See PR #161 that was merged and included in today's release (v1.9.0).

### Testing

There is a "ts type definitions" test file:

https://github.com/auth0/node-jwks-rsa/blob/master/tests/ts-definitions.tests.ts

But I'm not really sure what it's testing or how it's supposed to work.