### PR TITLE
Fix caching and rateLimiting on getSigningKeyAsync

### DIFF
--- a/src/JwksClient.js
+++ b/src/JwksClient.js
@@ -29,6 +29,10 @@ export class JwksClient {
     if (this.options.cache) {
       this.getSigningKey = cacheSigningKey(this, options);
     }
+    
+    if (this.options.rateLimit || this.options.cache) {
+      this.getSigningKeyAsync = promisifyIt(this.getSigningKey, this);
+    }
   }
 
   getKeys(cb) {


### PR DESCRIPTION
Adds the ability to use cache and rateLimit on the getSigningKeyAsync method

Fixes https://github.com/auth0/node-jwks-rsa/issues/171
