### PR TITLE
fix proxy agent for http

### DIFF
--- a/src/wrappers/request.js
+++ b/src/wrappers/request.js
@@ -1,7 +1,7 @@
 import http from 'http';
 import https from 'https';
 import url from 'url';
-import httpProxyAgent from 'https-proxy-agent';
+import httpProxyAgent from 'http-proxy-agent';
 import httpsProxyAgent from 'https-proxy-agent';
 import { request } from 'axios';
 


### PR DESCRIPTION
### Description

It seems `https-proxy-agent` has been used for both `httpProxyAgent` and `httpsProxyAgent`.
