### PR TITLE
Release 1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.10.1] - (2020-09-24)
+
+**Fixed**
+- fix dependencies for --production flag with npm [\#180](https://github.com/auth0/node-jwks-rsa/pull/180) ([alexrqs](https://github.com/alexrqs))
+
 ## [1.10.0] - (2020-09-23)
 
 **Added**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jwks-rsa",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwks-rsa",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Library to retrieve RSA public keys from a JWKS endpoint",
   "main": "lib/index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## [1.10.1] - (2020-09-24)

**Fixed**
- fix dependencies for --production flag with npm [\#180](https://github.com/auth0/node-jwks-rsa/pull/180) ([alexrqs](https://github.com/alexrqs))