### PR TITLE
Add ability to configure proxy with env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ const client = jwksClient({
 For more information, see [the NodeJS request library `agentOptions`
 documentation](https://github.com/request/request#using-optionsagentoptions).
 
+### Proxy configuration
+
+There are two ways to configure the usage of a proxy:
+ - Provide the ```proxy``` option when initialiting the client as shown above
+ - Provide the ```HTTP_PROXY```, ```HTTPS_PROXY``` and ```NO_PROXY``` environment variables
+
 ## Running Tests
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -6372,6 +6372,11 @@
         "ipaddr.js": "1.9.0"
       }
     },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "jsonwebtoken": "^8.5.1",
     "limiter": "^1.1.5",
     "lru-memoizer": "^2.1.2",
-    "ms": "^2.1.2"
+    "ms": "^2.1.2",
+    "proxy-from-env": "^1.1.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",

--- a/src/wrappers/request.js
+++ b/src/wrappers/request.js
@@ -4,6 +4,7 @@ import url from 'url';
 import httpProxyAgent from 'http-proxy-agent';
 import httpsProxyAgent from 'https-proxy-agent';
 import { request } from 'axios';
+import { getProxyForUrl } from 'proxy-from-env';
 
 export default function(options, cb) {
   const requestOptions = {
@@ -12,19 +13,19 @@ export default function(options, cb) {
     timeout: options.timeout
   };
 
-  if (options.proxy || options.agentOptions || options.strictSSL != undefined) {
+  const proxyUrl = options.proxy || getProxyForUrl(options.uri);
+  if (proxyUrl || options.agentOptions || options.strictSSL != undefined) {
     const agentOptions = {
       ...(options.strictSSL != undefined) && { rejectUnauthorized: options.strictSSL },
       ...(options.headers && { headers: options.headers }),
       ...options.agentOptions
     };
 
-    if (options.proxy) {
+    if (proxyUrl) {
       // Axios proxy workaround: https://github.com/axios/axios/issues/2072
-      const proxy = url.parse(options.proxy);
-      
+      const proxyOptions = url.parse(proxyUrl);
       requestOptions.proxy = false; //proxyParsed
-      const proxyAgentOptions = { ...agentOptions, ...proxy };
+      const proxyAgentOptions = { ...agentOptions, ...proxyOptions };
       requestOptions.httpAgent = new httpProxyAgent(proxyAgentOptions);
       requestOptions.httpsAgent = new httpsProxyAgent(proxyAgentOptions);
     } else {

--- a/tests/request.tests.js
+++ b/tests/request.tests.js
@@ -42,6 +42,28 @@ describe('Request wrapper tests', () => {
           done(err);
         });
       });
+
+      const expectAgent = (agent, host, port, protocol) => {
+        expect(agent.proxy.host).to.equal(host);
+        expect(agent.proxy.port).to.equal(port);
+        expect(agent.proxy.protocol).to.equal(protocol);
+      };
+
+      it('should pass the "proxy" option', (done) => {
+        request({ uri, proxy: 'http://dummy-proxy.org:123' }, (err, options) => {
+          expectAgent(options.httpsAgent, 'dummy-proxy.org', 123, 'http:');
+          done(err);
+        });
+      });
+
+      it('should read the proxy config from the environment', (done) => {
+        process.env.HTTPS_PROXY = 'http://another-dummy-proxy.org:456';
+        request({ uri }, (err, options) => {
+          expectAgent(options.httpsAgent, 'another-dummy-proxy.org', 456, 'http:');
+          process.env.HTTPS_PROXY = undefined;
+          done(err);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR adds a missing part of the workaround for the axios issue with corporate proxies.  
```request``` and ```axios``` as well provide the possibility to define proxy config via the environment variables HTTP_PROXY, HTTPS_PROXY and NO_PROXY. Currently the request wrapper doesn't interpret these env vars and doesn't create the needed ```https-proxy-agent```. As a result the axios internal proxy logic is applied which causes the problems with many corporate proxies.

This PR adds this missing functionality.


### References

https://github.com/auth0/node-jwks-rsa/issues/144
https://github.com/axios/axios/issues/2072

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
