### PR TITLE
fix: Do not publish examples

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 .babelrc
 .eslintrc
 src/
+examples/


### PR DESCRIPTION
Closes: #189

Currently, the examples directory is published in the npm package. This results in `jwks-rsa` being flagged with `CVE-2020-15084` since the example included installs express-jwt. A simple solution to this is to add `examples` to `.npmignore`

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

In CI checks, consumers of the jwks-rsa node module will scan the resulting images for known security vulnerabilities and block deploys when packages with known vulnerabilities are discovered.

Complicating matters, some modules publish to NPM with "example" directories containing other packages that aren't needed at runtime.  This practise stalls deployment pipelines and contributes unwanted files to runtime images.

`jwks-rsa:1.5.1` was flagged for including `express-jwt:3.4.0` in the examples directory.  This package was flagged for containing `CVE-2020-15084` at path `/usr/src/app/node_modules/jwks-rsa/examples/express-demo/node_modules/express-jwt`




### References

https://nvd.nist.gov/vuln/detail/CVE-2020-15084

### Testing

Publish dry-run:

> npm publish --dry-run

### Checklist

- [N/A] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
