### PR TITLE
docs: Fix 'cacheMaxAge' default value in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ const jwksClient = require('jwks-rsa');
 const client = jwksClient({
   cache: true, // Default Value
   cacheMaxEntries: 5, // Default value
-  cacheMaxAge: 10000, // Defaults to 10s
+  cacheMaxAge: 600000, // Defaults to 10m
   jwksUri: 'https://sandrino.auth0.com/.well-known/jwks.json'
 });
 


### PR DESCRIPTION
### Description

This purpose of this PR is to align 'cacheMaxAge' default value in README with the value in the actual codebase.
https://github.com/auth0/node-jwks-rsa/blob/b2e7a10ac721b6adb646e66c07a095b292e8f506/src/wrappers/cache.js#L5

https://github.com/auth0/node-jwks-rsa/blob/b2e7a10ac721b6adb646e66c07a095b292e8f506/README.md#L57
It should be 10 minutes instead of 10 seconds.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
