### PR TITLE
Introduces a Custom Cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ client.getSigningKey(kid, (err, key) => {
 });
 ```
 
+### Custom Caching
+
+The built-in caching uses in-memory memoization, however at times this strategy isn't flexible enough for certain use-cases.  To cover these scenarios you can supply a `customCache` to the client to cover your use-case.
+
+The only requirement of the `customCache` is that it has a `get` method with two arguments `(kid, getSigningKey)` and returns a promise.  You can review the [mock CustomCache](/tests/mocks/customCache.js) for an idea on a custom cache implementation.
+
+```js
+  client = new JwksClient({
+    jwksUri: `${jwksHost}/.well-known/jwks.json`,
+    cache: true,
+    customCache: new CustomCache()
+  });
+```
+
 ### Rate Limiting
 
 Even if caching is enabled the library will call the JWKS endpoint if the `kid` is not available in the cache, because a key rotation could have taken place. To prevent attackers to send many random `kid`s you can also configure rate limiting. This will allow you to limit the number of calls that are made to the JWKS endpoint per minute (because it would be highly unlikely that signing keys are rotated multiple times per minute).

--- a/src/wrappers/cache.js
+++ b/src/wrappers/cache.js
@@ -2,11 +2,19 @@ import ms from 'ms';
 import debug from 'debug';
 import memoizer from 'lru-memoizer';
 
-export default function(client, { cacheMaxEntries = 5, cacheMaxAge = ms('10m') } = options) {
+export default function(client, { customCache, cacheMaxEntries = 5, cacheMaxAge = ms('10m') } = options) {
   const logger = debug('jwks');
   const getSigningKey = client.getSigningKey;
 
   logger(`Configured caching of signing keys. Max: ${cacheMaxEntries} / Age: ${cacheMaxAge}`);
+
+  if (customCache) {
+    return (kid, callback) => 
+      customCache.get(kid, getSigningKey)
+        .then(key => callback(null, key))
+        .catch(err => callback(err));
+  }
+
   return memoizer({
     load: (kid, callback) => {
       getSigningKey(kid, (err, key) => {

--- a/tests/cache.tests.js
+++ b/tests/cache.tests.js
@@ -1,8 +1,10 @@
 import nock from 'nock';
 import { expect } from 'chai';
 
-import { x5cSingle } from './keys';
+import { x5cSingle, x5cMultiple } from './keys';
 import { JwksClient } from '../src/JwksClient';
+
+import CustomCache from './mocks/CustomCache';
 
 describe('JwksClient (cache)', () => {
   const jwksHost = 'http://my-authz-server';
@@ -14,7 +16,7 @@ describe('JwksClient (cache)', () => {
   describe('#getSigningKey', () => {
     describe('should cache requests per kid', () => {
       let client;
-
+      
       before((done) => {
         nock(jwksHost)
           .get('/.well-known/jwks.json')
@@ -46,6 +48,47 @@ describe('JwksClient (cache)', () => {
       it('should fetch the key from the cache', (done) => {
         client.getSigningKey('NkFCNEE1NDFDNTQ5RTQ5OTE1QzRBMjYyMzY0NEJCQTJBMjJBQkZCMA', (err, key) => {
           expect(key.kid).to.equal('NkFCNEE1NDFDNTQ5RTQ5OTE1QzRBMjYyMzY0NEJCQTJBMjJBQkZCMA');
+          done();
+        });
+      });
+    });
+  
+    describe('when using customCache', () => {
+      let client;
+      const keyOne = x5cMultiple.keys[0];
+      const keyTwo = x5cMultiple.keys[1];
+
+      before((done) => {
+        nock(jwksHost)
+          .get('/.well-known/jwks.json')
+          .reply(200, { keys: [ keyOne ] });
+
+        client = new JwksClient({
+          jwksUri: `${jwksHost}/.well-known/jwks.json`,
+          cache: true,
+          customCache: new CustomCache([ keyTwo ])
+        });
+
+        // Cache the Key
+        client.getSigningKey(keyOne.kid, (err, key) => {
+          expect(key.kid).to.equal(keyOne.kid);
+
+          // Stop the JWKS server
+          nock.cleanAll();
+          done();
+        });
+      });
+
+      it('should fetch the key from the customCache', (done) => {
+        client.getSigningKey(keyOne.kid, (err, key) => {
+          expect(key.kid).to.equal(keyOne.kid);
+          done();
+        });
+      });
+
+      it('should fetch key from customized cache implementation', (done) => {
+        client.getSigningKey(keyTwo.kid, (err, key) => {
+          expect(key.kid).to.equal(keyTwo.kid);
           done();
         });
       });

--- a/tests/mocks/customCache.js
+++ b/tests/mocks/customCache.js
@@ -1,0 +1,25 @@
+export default class CustomCache {
+  constructor(keys = []) {
+    this.keys = keys;
+  }
+
+  get(kid, getSigningKey) {
+    const key = this.has(kid);
+    if (key) { return Promise.resolve(key); }
+
+    return new Promise((resolve, reject) => {
+      getSigningKey(kid, (err, key) => {
+        if (err) { return reject(err); }
+
+        this.set(key);
+        return resolve(key);
+      });
+    });
+  }
+  has(kid) {
+    return this.keys.find(k => k.kid === kid);
+  }
+  set(key) {
+    return this.keys.push(key);
+  }
+}


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

There has been discussion around the need for a more flexible cache (issues/prs listed in references below). This PR introduces the ability for a developer to override the built-in cache and use their own Custom Cache.  This replaces #141 as discussed here https://github.com/auth0/node-jwks-rsa/pull/141#issuecomment-726177566

### References

* Helps resolve https://github.com/auth0/node-jwks-rsa/issues/158
* Replaces https://github.com/auth0/node-jwks-rsa/pull/141

### Testing

Added tests to cover the use of a custom cache.  Additionally added a mock customCache for an idea of what a custom cache implementation might look like

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
