### PR TITLE
Release 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,22 @@
 # Changelog
+## [1.12.0] - (2020-12-08)
+
+**Added**
+- Provide an alternative source for supplying keysets [\#292](https://github.com/auth0/node-jwks-rsa/pull/292) ([davidpatrick](https://github.com/davidpatrick))
+
+**Deprecation**
+We are deprecating passing in a `jwksObject` to the client for reasons laid out in [\#292](https://github.com/auth0/node-jwks-rsa/pull/292).  In order to load keys from anything other than the `jwksUri`, please use the `getKeysInterceptor`.
+
+```js
+  const client = new JwksClient({ 
+    jwksUri: 'https://my-enterprise-id-provider/.well-known/jwks.json',
+    getKeysInterceptor: (cb) => {
+      const file = fs.readFileSync(jwksFile);
+      return cb(null, file.keys);
+    }
+  });
+```
+
 ## [1.11.0] - (2020-10-23)
 
 **Added**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jwks-rsa",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwks-rsa",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Library to retrieve RSA public keys from a JWKS endpoint",
   "main": "lib/index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## [1.12.0] - (2020-12-08)

**Added**
- Provide an alternative source for supplying keysets [\#292](https://github.com/auth0/node-jwks-rsa/pull/292) ([davidpatrick](https://github.com/davidpatrick))

**Deprecation**
We are deprecating passing in a `jwksObject` to the client for reasons laid out in [\#292](https://github.com/auth0/node-jwks-rsa/pull/292).  In order to load keys from anything other than the `jwksUri`, please use the `getKeysInterceptor`.

```js
  const client = new JwksClient({ 
    jwksUri: 'https://my-enterprise-id-provider/.well-known/jwks.json',
    getKeysInterceptor: (cb) => {
      const file = fs.readFileSync(jwksFile);
      return cb(null, file.keys);
    }
  });
```