### PR TITLE
Add types for agent options used by ExpressJwtOptions 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,6 @@
 import { SecretCallback, SecretCallbackLong } from 'express-jwt';
+import { AgentOptions as HttpAgentOptions } from 'http';
+import { AgentOptions as HttpsAgentOptions } from 'https';
 
 declare function JwksRsa(options: JwksRsa.ClientOptions): JwksRsa.JwksClient;
 
@@ -29,6 +31,7 @@ declare namespace JwksRsa {
     strictSsl?: boolean;
     requestHeaders?: Headers;
     timeout?: number;
+    requestAgentOptions?: HttpAgentOptions | HttpsAgentOptions;
     getKeysInterceptor?(cb: (err: Error | null, keys: SigningKey[]) => void): void;
   }
 
@@ -46,10 +49,6 @@ declare namespace JwksRsa {
     publicKey: string;
   }
 
-  interface AgentOptions {
-    [key: string]: string;
-  }
-
   interface Options {
     jwksUri: string;
     rateLimit?: boolean;
@@ -59,7 +58,7 @@ declare namespace JwksRsa {
     jwksRequestsPerMinute?: number;
     strictSsl?: boolean;
     requestHeaders?: Headers;
-    requestAgentOptions?: AgentOptions;
+    requestAgentOptions?: HttpAgentOptions | HttpsAgentOptions;
     handleSigningKeyError?(err: Error, cb: (err: Error) => void): any;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -615,9 +615,9 @@
       }
     },
     "@types/node": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.2.tgz",
-      "integrity": "sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA=="
+      "version": "14.14.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.12.tgz",
+      "integrity": "sha512-ASH8OPHMNlkdjrEdmoILmzFfsJICvhBsFfAum4aKZ/9U4B6M6tTmTPh+f3ttWdD74CEGV5XvXWkbyfSdXaTd7g=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -893,11 +893,11 @@
       "optional": true
     },
     "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha1-PqNsXYgY0NX4qKl6bTa4bNwAyyc=",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
+      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
       "requires": {
-        "follow-redirects": "1.5.10"
+        "follow-redirects": "^1.10.0"
       }
     },
     "babel-cli": {
@@ -3309,27 +3309,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha1-e3qfmuov3/NnhqlP9kPtB/T/Xio=",
-      "requires": {
-        "debug": "=3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "index.d.ts",
   "dependencies": {
     "@types/express-jwt": "0.0.42",
-    "axios": "^0.19.2",
+    "axios": "^0.20.0",
     "debug": "^4.1.0",
     "http-proxy-agent": "^4.0.1",
     "https-proxy-agent": "^5.0.0",
@@ -20,6 +20,7 @@
     "@types/chai": "^4.2.11",
     "@types/mocha": "^5.2.7",
     "@types/nock": "^10.0.3",
+    "@types/node": "^14.14.12",
     "babel-cli": "^6.9.0",
     "babel-core": "^6.9.0",
     "babel-eslint": "^8.2.6",


### PR DESCRIPTION
This adds `AgentOptions` to the `ClientOptions` interface which is inherited by `ExpressJwtOptions`.  This will Close #167 

Additionally bumping Axios minor (closes #200) and moving the @types for express-jwt to devDependencies.
