### PR TITLE
Fix PR link in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 ## [1.12.0] - (2020-12-08)
 
 **Added**
-- Provide an alternative source for supplying keysets [\#292](https://github.com/auth0/node-jwks-rsa/pull/292) ([davidpatrick](https://github.com/davidpatrick))
+- Provide an alternative source for supplying keysets [\#202](https://github.com/auth0/node-jwks-rsa/pull/202) ([davidpatrick](https://github.com/davidpatrick))
 
 **Deprecation**
-We are deprecating passing in a `jwksObject` to the client for reasons laid out in [\#292](https://github.com/auth0/node-jwks-rsa/pull/292).  In order to load keys from anything other than the `jwksUri`, please use the `getKeysInterceptor`.
+We are deprecating passing in a `jwksObject` to the client for reasons laid out in [\#202](https://github.com/auth0/node-jwks-rsa/pull/202).  In order to load keys from anything other than the `jwksUri`, please use the `getKeysInterceptor`.
 
 ```js
   const client = new JwksClient({ 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

The current link 404s. Honestly the new link is a bit of a guess but seems to fit and is a likely typo. 

Sorry for not opening an issue, this seems trivial enough that that'd be overkill. Note that the release page might also need updating: https://github.com/auth0/node-jwks-rsa/releases/tag/v1.12.0


### Testing
N/A

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
