### PR TITLE
Bump Axios to ^0.21.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -893,9 +893,9 @@
       "optional": true
     },
     "axios": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
         "follow-redirects": "^1.10.0"
       }
@@ -3309,9 +3309,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "index.d.ts",
   "dependencies": {
     "@types/express-jwt": "0.0.42",
-    "axios": "^0.20.0",
+    "axios": "^0.21.1",
     "debug": "^4.1.0",
     "http-proxy-agent": "^4.0.1",
     "https-proxy-agent": "^5.0.0",


### PR DESCRIPTION
### Description

This Axios version fixes an SSRF vulnerability:

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-28168

### References

The Axios changelog since 0.20.0 seems reasonable:

https://github.com/axios/axios/blob/a64050a6cfbcc708a55a7dc8030d85b1c78cdf38/CHANGELOG.md#0211-december-21-2020

Closes #200.
