### PR TITLE
V2 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,87 @@
 # Changelog
 
+## [2.0.0] - (2021-03-01)
+With version 2 we have added full JWK/JWS support.  With this we have bumped the node version to minimum 10.  We have also removed Axios and exposed a `fetcher` option to allow user's to completely override how the request to the `jwksUri` endpoint is made.
+
+### Breaking Changes
+* Drops support for Node < 10
+* No more callbacks, using async/await(promises)
+* Removed Axios and changed the API to JwksClient
+
+### Changes
+**Added**
+- Full JWK/JWS Support [\#205](https://github.com/auth0/node-jwks-rsa/pull/205) ([panva](https://github.com/panva))
+
+**Changed**
+- Simplify request wrapper [\#218](https://github.com/auth0/node-jwks-rsa/pull/218) ([davidpatrick](https://github.com/davidpatrick))
+- Pins to Node Version 10,12,14 [\#212](https://github.com/auth0/node-jwks-rsa/pull/212) ([davidpatrick](https://github.com/davidpatrick))
+- Migrate from callbacks to async/await [\#222](https://github.com/auth0/node-jwks-rsa/pull/222) ([davidpatrick](https://github.com/davidpatrick))
+
+### Migration Guide from v1 to v2
+#### Proxies
+The proxy option has been removed from the JwksClient.  Support for it was a little spotty through Axios, and we wanted to allow users to have more control over the flow.  Now you can specify your proxy by overriding the `requestAgent` used with an [agent with built-in proxy support](https://github.com/TooTallNate/node-https-proxy-agent), or by completely overriding the request library with the `fetcher` option.
+
+```js
+// OLD
+const oldClient = jwksClient({
+  jwksUri: 'https://sandrino.auth0.com/.well-known/jwks.json',
+  proxy: 'https://username:pass@address:port'
+});
+
+// NEW
+const HttpsProxyAgent = require('https-proxy-agent');
+const newClient = jwksClient({
+  jwksUri: 'https://sandrino.auth0.com/.well-known/jwks.json',
+  requestAgent: new HttpsProxyAgent('https://username:pass@address:port')
+});
+```
+
+#### Request Agent Options
+The library no longer gates what http(s) Agent is used, so we have removed `requestAgentOptions` and now expose the `requestAgent` option when creating a `jwksClient`.
+
+```js
+// OLD
+const oldClient = jwksClient({
+  jwksUri: 'https://sandrino.auth0.com/.well-known/jwks.json',
+  requestAgentOptions: {
+    ca: fs.readFileSync(caFile)
+  }
+});
+
+// NEW
+const newClient = jwksClient({
+  jwksUri: 'https://sandrino.auth0.com/.well-known/jwks.json',
+  requestAgent: new https.Agent({
+    ca: fs.readFileSync(caFile)
+  })
+});
+```
+
+#### Migrated Callbacks to Async/Await
+The library no longer supports callbacks.  We have migrated to async/await(promises).
+
+```js
+// OLD
+client.getSigningKey(kid, (err, key) => {
+  const signingKey = key.getPublicKey();
+});
+
+// NEW
+const key = await client.getSigningKey(kid);
+const signingKey = key.getPublicKey();
+```
+
+## [1.12.3] - (2021-02-25)
+
+**Added**
+- Add alg to SigningKey types [\#220](https://github.com/auth0/node-jwks-rsa/pull/220) ([okko](https://github.com/okko))
+
+**Fixed**
+
+- Fix npmjs resolves [\#221](https://github.com/auth0/node-jwks-rsa/pull/221) ([adamjmcgrath](https://github.com/adamjmcgrath))
+- Fix Import default Axios instance [\#216](https://github.com/auth0/node-jwks-rsa/pull/216) ([dsebastien](https://github.com/dsebastien)) 
+
+
 ## [1.12.2] - (2021-01-07)
 
 **Fixed**

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ You'll provide the client with the JWKS endpoint which exposes your signing keys
 const jwksClient = require('jwks-rsa');
 
 const client = jwksClient({
-  strictSsl: true, // Default value
   jwksUri: 'https://sandrino.auth0.com/.well-known/jwks.json',
   requestHeaders: {}, // Optional
   timeout: 30000 // Defaults to 30s
@@ -30,14 +29,33 @@ const key = await client.getSigningKey(kid);
 const signingKey = key.getPublicKey();
 ```
 
-> Note that all methods on the `JwksClient` have asynchronous equivalents, where the promisified name is suffixed with `Async`, e.g., `client.getSigningKeyAsync(kid).then(key => { /* ... */ })`;
-
-Integrations are also provided with:
+### Integrations
 
  - [express/express-jwt](examples/express-demo)
  - [express/passport-jwt](examples/passport-demo)
  - [hapi/hapi-auth-jwt2](examples/hapi-demo)
  - [koa/koa-jwt](examples/koa-demo)
+
+### API
+
+#### JwksClient Options
+
+- `jwksUri`: a string that represents the JWKS URI
+- `timeout = 30000`: (_optional_) an integer in miliseconds that controls the request timeout
+- `cache = true`: (_optional_) enables a LRU Cache [(details)](#caching)
+- `rateLimit`: (_optional_) the default fetcher function [(details)](#rate-limiting)
+- `fetcher`: (_optional_) a Promise returning function to fetch data from the JWKS URI
+- `requestHeaders`: (_optional_) an object of headers to pass to the request
+- `requestAgent`: (_optional_) a Node `http.Agent` to be passed to the http(s) request
+- `getKeysInterceptor`: (_optional_) a promise returning function hook [(details)](#loading-keys-from-local-file-environment-variable-or-other-externals)
+
+#### Return Values
+
+- `data`: data for the given key resolved by `fetcher` (or undefined if not loaded)
+- `error`: error thrown by `fetcher` (or undefined)
+- `isValidating`: if there's a request or revalidation loading
+- `mutate(data?, shouldRevalidate?)`: function to mutate the cached data
+
 
 ### Caching
 
@@ -86,7 +104,6 @@ certificate authority to establish TLS communication with the `jwks_uri`.
 const jwksClient = require("jwks-rsa");
 const https = require('https');
 const client = jwksClient({
-  strictSsl: true, // Default value
   jwksUri: 'https://my-enterprise-id-provider/.well-known/jwks.json',
   requestHeaders: {}, // Optional
   requestAgent: new https.Agent({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jwks-rsa",
-  "version": "1.12.2",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwks-rsa",
-  "version": "1.12.2",
+  "version": "2.0.0",
   "description": "Library to retrieve RSA public keys from a JWKS endpoint",
   "main": "lib/index.js",
   "types": "index.d.ts",


### PR DESCRIPTION

## [2.0.0] - (2021-03-01)
With version 2 we have added full JWK/JWS support.  With this we have bumped the node version to minimum 10.  We have also removed Axios and exposed a `fetcher` option to allow user's to completely override how the request to the `jwksUri` endpoint is made.

### Breaking Changes
* Drops support for Node < 10
* No more callbacks, using async/await(promises)
* Removed Axios and changed the API to JwksClient

### Changes
**Added**
- Full JWK/JWS Support [\#205](https://github.com/auth0/node-jwks-rsa/pull/205) ([panva](https://github.com/panva))

**Changed**
- Simplify request wrapper [\#218](https://github.com/auth0/node-jwks-rsa/pull/218) ([davidpatrick](https://github.com/davidpatrick))
- Pins to Node Version 10,12,14 [\#212](https://github.com/auth0/node-jwks-rsa/pull/212) ([davidpatrick](https://github.com/davidpatrick))
- Migrate from callbacks to async/await [\#222](https://github.com/auth0/node-jwks-rsa/pull/222) ([davidpatrick](https://github.com/davidpatrick))

### Migration Guide from v1 to v2
#### Proxies
The proxy option has been removed from the JwksClient.  Support for it was a little spotty through Axios, and we wanted to allow users to have more control over the flow.  Now you can specify your proxy by overriding the `requestAgent` used with an [agent with built-in proxy support](https://github.com/TooTallNate/node-https-proxy-agent), or by completely overriding the request library with the `fetcher` option.

```js
// OLD
const oldClient = jwksClient({
  jwksUri: 'https://sandrino.auth0.com/.well-known/jwks.json',
  proxy: 'https://username:pass@address:port'
});

// NEW
const HttpsProxyAgent = require('https-proxy-agent');
const newClient = jwksClient({
  jwksUri: 'https://sandrino.auth0.com/.well-known/jwks.json',
  requestAgent: new HttpsProxyAgent('https://username:pass@address:port')
});
```

#### Request Agent Options
The library no longer gates what http(s) Agent is used, so we have removed `requestAgentOptions` and now expose the `requestAgent` option when creating a `jwksClient`.

```js
// OLD
const oldClient = jwksClient({
  jwksUri: 'https://sandrino.auth0.com/.well-known/jwks.json',
  requestAgentOptions: {
    ca: fs.readFileSync(caFile)
  }
});

// NEW
const newClient = jwksClient({
  jwksUri: 'https://sandrino.auth0.com/.well-known/jwks.json',
  requestAgent: new https.Agent({
    ca: fs.readFileSync(caFile)
  })
});
```

#### Migrated Callbacks to Async/Await
The library no longer supports callbacks.  We have migrated to async/await(promises).

```js
// OLD
client.getSigningKey(kid, (err, key) => {
  const signingKey = key.getPublicKey();
});

// NEW
const key = await client.getSigningKey(kid);
const signingKey = key.getPublicKey();
```