### PR TITLE
Fix typescript declarations for v2

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,12 +8,9 @@ declare namespace JwksRsa {
   class JwksClient {
     constructor(options: Options);
 
-    getKeys(cb: (err: Error | null, keys: unknown) => void): void;
-    getKeysAsync(): Promise<unknown>;
-    getSigningKeys(cb: (err: Error | null, keys: SigningKey[]) => void): void;
-    getSigningKeysAsync(): Promise<SigningKey[]>;
-    getSigningKey(kid: string, cb: (err: Error | null, key: SigningKey) => void): void;
-    getSigningKeyAsync(kid: string): Promise<SigningKey>;
+    getKeys(): Promise<unknown>;
+    getSigningKeys(): Promise<SigningKey[]>;
+    getSigningKey(kid: string): Promise<SigningKey>;
   }
 
   interface Headers {

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,7 @@ declare namespace JwksRsa {
     getKeys(): Promise<unknown>;
     getSigningKeys(): Promise<SigningKey[]>;
     getSigningKey(kid: string): Promise<SigningKey>;
+    getSigningKey(kid: string, cb: (err: Error | null, key: SigningKey) => void): void;
   }
 
   interface Headers {
@@ -29,7 +30,7 @@ declare namespace JwksRsa {
     timeout?: number;
     requestAgent?: HttpAgent | HttpsAgent;
     fetcher?(jwksUri: string): Promise<{ keys: SigningKey[] }>;
-    getKeysInterceptor?(cb: (err: Error | null, keys: SigningKey[]) => void): void;
+    getKeysInterceptor?(): Promise<SigningKey[]>;
   }
 
   interface CertSigningKey {


### PR DESCRIPTION
The v2 removed the callback based methods from the client and removed the Async suffix from the promise based methods.
The typescript prototype was not aligned with this change though, which makes it hard for typescript developers to "catch" such change by upgrading the package.
It also makes it hard for first time users of this package to discover the methods and what's available.

This PR fixes the misalignment created by the changes in v2

Closes #228 and #230 