### PR TITLE
fix typescript types for fetcher

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,12 +8,9 @@ declare namespace JwksRsa {
   class JwksClient {
     constructor(options: Options);
 
-    getKeys(cb: (err: Error | null, keys: unknown) => void): void;
-    getKeysAsync(): Promise<unknown>;
-    getSigningKeys(cb: (err: Error | null, keys: SigningKey[]) => void): void;
-    getSigningKeysAsync(): Promise<SigningKey[]>;
-    getSigningKey(kid: string, cb: (err: Error | null, key: SigningKey) => void): void;
-    getSigningKeyAsync(kid: string): Promise<SigningKey>;
+    getKeys(): Promise<unknown>;
+    getSigningKeys(): Promise<SigningKey[]>;
+    getSigningKey(kid: string): Promise<SigningKey>;
   }
 
   interface Headers {
@@ -31,7 +28,7 @@ declare namespace JwksRsa {
     requestHeaders?: Headers;
     timeout?: number;
     requestAgent?: HttpAgent | HttpsAgent;
-    fetcher?(jwksUri: string): Promise<{ keys: SigningKey[] }>;
+    fetcher?(jwksUri: string): Promise<{ keys: any }>;
     getKeysInterceptor?(cb: (err: Error | null, keys: SigningKey[]) => void): void;
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,9 +8,12 @@ declare namespace JwksRsa {
   class JwksClient {
     constructor(options: Options);
 
-    getKeys(): Promise<unknown>;
-    getSigningKeys(): Promise<SigningKey[]>;
-    getSigningKey(kid: string): Promise<SigningKey>;
+    getKeys(cb: (err: Error | null, keys: unknown) => void): void;
+    getKeysAsync(): Promise<unknown>;
+    getSigningKeys(cb: (err: Error | null, keys: SigningKey[]) => void): void;
+    getSigningKeysAsync(): Promise<SigningKey[]>;
+    getSigningKey(kid: string, cb: (err: Error | null, key: SigningKey) => void): void;
+    getSigningKeyAsync(kid: string): Promise<SigningKey>;
   }
 
   interface Headers {


### PR DESCRIPTION
fetcher shouldn't really return a SigningKey, becuase that's a complex instance with methods. there might be a better signature than any but I think this is good enough considering the scope of this (ie we don't want to define all possible fields of a jwk)

reopened from #230 