### PR TITLE
Update type def for getSigningKey

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,8 +10,8 @@ declare namespace JwksRsa {
 
     getKeys(): Promise<unknown>;
     getSigningKeys(): Promise<SigningKey[]>;
-    getSigningKey(kid: string): Promise<SigningKey>;
-    getSigningKey(kid: string, cb: (err: Error | null, key: SigningKey) => void): void;
+    getSigningKey(kid?: string | null | undefined): Promise<SigningKey>;
+    getSigningKey(kid: string | null | undefined, cb: (err: Error | null, key: SigningKey) => void): void;
   }
 
   interface Headers {


### PR DESCRIPTION
kid can be undefined or null for `getSigningKey` with callback, its completely optional when using the promise, this fixes the type definition

closes #235 