### PR TITLE
Interceptor bind client

### DIFF
--- a/src/wrappers/interceptor.js
+++ b/src/wrappers/interceptor.js
@@ -5,7 +5,7 @@ const retrieveSigningKeys = require('../utils').retrieveSigningKeys;
  * external cache, or provided object before falling back to the jwksUri endpoint
  */
 function getKeysInterceptor(client, { getKeysInterceptor } = options) {
-  const getSigningKey = client.getSigningKey;
+  const getSigningKey = client.getSigningKey.bind(client);
 
   return async (kid) => {
     const keys = await getKeysInterceptor();

--- a/tests/interceptor.tests.js
+++ b/tests/interceptor.tests.js
@@ -1,0 +1,43 @@
+const nock = require('nock');
+const { expect } = require('chai');
+
+const { x5cSingle, x5cMultiple } = require('./keys');
+const { JwksClient } = require('../src/JwksClient');
+
+describe('JwksClient (interceptor)', () => {
+  const jwksHost = 'http://my-authz-server';
+
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  describe('#getSigningKeys', () => {
+    it('should prefer key from interceptor', async () => {
+      const client = new JwksClient({
+        jwksUri: `${jwksHost}/.well-known/jwks.json`,
+        getKeysInterceptor: () => Promise.resolve(x5cSingle.keys)
+      });
+
+      nock(jwksHost)
+        .get('/.well-known/jwks.json')
+        .replyWithError('Call to jwksUri not expected');
+
+      const key = await client.getSigningKey('NkFCNEE1NDFDNTQ5RTQ5OTE1QzRBMjYyMzY0NEJCQTJBMjJBQkZCMA');
+      expect(key.kid).to.equal('NkFCNEE1NDFDNTQ5RTQ5OTE1QzRBMjYyMzY0NEJCQTJBMjJBQkZCMA');
+    });
+
+    it('should fallback to fetch from jwksUri', async () => {
+      const client = new JwksClient({
+        jwksUri: `${jwksHost}/.well-known/jwks.json`,
+        getKeysInterceptor: () => Promise.resolve([])
+      });
+
+      nock(jwksHost)
+        .get('/.well-known/jwks.json')
+        .reply(200, x5cMultiple);
+
+      const key = await client.getSigningKey('RkI5MjI5OUY5ODc1N0Q4QzM0OUYzNkVGMTJDOUEzQkFCOTU3NjE2Rg');
+      expect(key.kid).to.equal('RkI5MjI5OUY5ODc1N0Q4QzM0OUYzNkVGMTJDOUEzQkFCOTU3NjE2Rg');
+    });
+  });
+});


### PR DESCRIPTION
### Description
the `client` was not bound to `getSigningKey` in interceptor.js, making `this` undefined in the `JwksClient` instance.
This was causing a `TypeError`when the interceptor would not return a key.

```
     TypeError: Cannot read property 'logger' of undefined
      at getSigningKey (src/JwksClient.js:71:10)
      at JwksClient.<anonymous> (src/wrappers/interceptor.js:26:12)
      at async Context.<anonymous> (tests/interceptor.tests.js:39:19)

```

### References

### Testing
Unit tests added to reproduce the error, and verify the fix.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
