### PR TITLE
Idiomatic use of debug lib 

### DIFF
--- a/src/JwksClient.js
+++ b/src/JwksClient.js
@@ -1,4 +1,4 @@
-const debug = require('debug');
+const logger = require('debug')('jwks');
 const { retrieveSigningKeys } = require('./utils') ;
 const { request, cacheSigningKey, rateLimitSigningKey, getKeysInterceptor, callbackSupport } = require('./wrappers');
 const JwksError = require('./errors/JwksError');
@@ -12,7 +12,6 @@ class JwksClient {
       timeout: 30000,
       ...options
     };
-    this.logger = debug('jwks');
 
     // Initialize wrappers.
     if (this.options.getKeysInterceptor) {
@@ -30,7 +29,7 @@ class JwksClient {
   }
 
   async getKeys() {
-    this.logger(`Fetching keys from '${this.options.jwksUri}'`);
+    logger(`Fetching keys from '${this.options.jwksUri}'`);
 
     try {
       const res = await request({
@@ -41,11 +40,11 @@ class JwksClient {
         fetcher: this.options.fetcher
       });
 
-      this.logger('Keys:', res.keys);  
+      logger('Keys:', res.keys);
       return res.keys;
     } catch (err) {
       const { errorMsg } = err;
-      this.logger('Failure:', errorMsg || err);
+      logger('Failure:', errorMsg || err);
       throw (errorMsg ? new JwksError(errorMsg) : err);
     }
   }
@@ -63,17 +62,17 @@ class JwksClient {
       throw new JwksError('The JWKS endpoint did not contain any signing keys');
     }
 
-    this.logger('Signing Keys:', signingKeys);
+    logger('Signing Keys:', signingKeys);
     return signingKeys;
   }
 
   async getSigningKey (kid) {
-    this.logger(`Fetching signing key for '${kid}'`);
+    logger(`Fetching signing key for '${kid}'`);
     const keys = await this.getSigningKeys();
 
     const kidDefined = kid !== undefined && kid !== null;
     if (!kidDefined && keys.length > 1) {
-      this.logger('No KID specified and JWKS endpoint returned more than 1 key');
+      logger('No KID specified and JWKS endpoint returned more than 1 key');
       throw new SigningKeyNotFoundError('No KID specified and JWKS endpoint returned more than 1 key');
     }
 
@@ -81,7 +80,7 @@ class JwksClient {
     if (key) {
       return key;
     } else {
-      this.logger(`Unable to find a signing key that matches '${kid}'`);
+      logger(`Unable to find a signing key that matches '${kid}'`);
       throw new SigningKeyNotFoundError(`Unable to find a signing key that matches '${kid}'`);
     }
   }

--- a/src/wrappers/cache.js
+++ b/src/wrappers/cache.js
@@ -1,8 +1,7 @@
-const debug = require('debug');
+const logger = require('debug')('jwks');
 const memoizer = require('lru-memoizer');
 
 function cacheWrapper(client, { cacheMaxEntries = 5, cacheMaxAge = 600000 }) {
-  const logger = debug('jwks');
   logger(`Configured caching of signing keys. Max: ${cacheMaxEntries} / Age: ${cacheMaxAge}`);
   return memoizer.sync({
     hash: (kid) => kid,

--- a/src/wrappers/rateLimit.js
+++ b/src/wrappers/rateLimit.js
@@ -1,10 +1,9 @@
-const debug = require('debug');
+const logger = require('debug')('jwks');
 const { RateLimiter } = require('limiter');
 
 const JwksRateLimitError = require('../errors/JwksRateLimitError');
 
 function rateLimtWrapper(client, { jwksRequestsPerMinute = 10 }) {
-  const logger = debug('jwks');
   const getSigningKey = client.getSigningKey.bind(client);
 
   const limiter = new RateLimiter(jwksRequestsPerMinute, 'minute', true);


### PR DESCRIPTION
### Description

Initially this MR was to fix a potential memory leak by not GC the debug lib. However a cached client should be used anyways. This PR is more to keep with the idiomatic us of the library.

### References

Addresses issue https://github.com/auth0/node-jwks-rsa/issues/266

### Testing

N/A

### Checklist

- [ N/A] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ N/A] All active GitHub checks for tests, formatting, and security are passing
- [ N/A] The correct base branch is being used, if not `master`
