### PR TITLE
Destroy the request when reaches the timeout (#270)

### DIFF
--- a/src/wrappers/request.js
+++ b/src/wrappers/request.js
@@ -26,7 +26,7 @@ module.exports.default =  (options) => {
     };
 
     const httpRequestLib = protocol === 'https:' ? https : http;
-    httpRequestLib.request(requestOptions, (res) => {
+    const httpRequest = httpRequestLib.request(requestOptions, (res) => {
       let rawData = '';
       res.setEncoding('utf8');
       res.on('data', (chunk) => { rawData += chunk; });
@@ -42,7 +42,10 @@ module.exports.default =  (options) => {
           }
         }
       });
-    })
+    });
+
+    httpRequest
+      .on('timeout', () => httpRequest.destroy())
       .on('error', (e) => reject(e))
       .end();
   });

--- a/tests/request.tests.js
+++ b/tests/request.tests.js
@@ -69,6 +69,24 @@ describe('Request wrapper tests', () => {
     request({ uri, timeout });
   });
 
+  it('should destroy the request when reaches the timeout', (done) => {
+    const timeout = 5;
+    const latency = timeout + 5;
+    const errorCode = 'ECONNRESET';
+
+    nock(jwksHost)
+      .get('/.well-known/jwks.json')
+      .delay(latency)
+      .reply(200, jwksJson);
+
+    request({ uri, timeout })
+      .then(() => done('Should have thrown error'))
+      .catch((err) => {
+        expect(err.code).to.eql(errorCode);
+        done();
+      });
+  });
+
   it('should set modify headers when specified in options', (done) => {
     const headers = { 'test': '123' };
 


### PR DESCRIPTION
### Description

This is a fix to the timeout issue described in #270 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
