### PR TITLE
Release v2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [v2.0.5](https://github.com/auth0/node-jwks-rsa/tree/v2.0.5) (2021-10-15)
+[Full Changelog](https://github.com/auth0/node-jwks-rsa/compare/v2.0.4...v2.0.5)
+
+**Fixed**
+- Destroy the request when reaches the timeout (#270) [\#271](https://github.com/auth0/node-jwks-rsa/pull/271) ([amrsalama](https://github.com/amrsalama))
+- [SDK-2833] Fix issue where errors were being cached [\#268](https://github.com/auth0/node-jwks-rsa/pull/268) ([adamjmcgrath](https://github.com/adamjmcgrath))
+
 ## [2.0.4] - (2021-07-16)
 
 **Fixed**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jwks-rsa",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwks-rsa",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Library to retrieve RSA public keys from a JWKS endpoint",
   "main": "src/index.js",
   "files": [


### PR DESCRIPTION

**Fixed**
- Destroy the request when reaches the timeout (#270) [\#271](https://github.com/auth0/node-jwks-rsa/pull/271) ([amrsalama](https://github.com/amrsalama))
- [SDK-2833] Fix issue where errors were being cached [\#268](https://github.com/auth0/node-jwks-rsa/pull/268) ([adamjmcgrath](https://github.com/adamjmcgrath))


[SDK-2833]: https://auth0team.atlassian.net/browse/SDK-2833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ