### PR TITLE
fix(type): correct the wrong type of the `getSigningKey` function arg…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ declare namespace JwksRsa {
     getKeys(): Promise<unknown>;
     getSigningKeys(): Promise<SigningKey[]>;
     getSigningKey(kid?: string | null | undefined): Promise<SigningKey>;
-    getSigningKey(kid: string | null | undefined, cb: (err: Error | null, key: SigningKey) => void): void;
+    getSigningKey(kid: string | null | undefined, cb: (err: Error | null, key?: SigningKey) => void): void;
   }
 
   interface Headers {


### PR DESCRIPTION
### Description

fix(type): correct the wrong type of the `getSigningKey` function argument

* If the `err` argument value is not null, the key argument value is `undefined`.


```ts
// Example
client.getSigningKey(header.kid, function (err, key) {
    console.log(`=== Test ===`);
    console.log(`err ≥`, err);
    console.log(`key ≥`, key);
    callback(err, key?.getPublicKey());
});
```
```bash
# Result
=== Test ===
err ≥ TypeError: jwks must be a JSON Web Key Set formatted object
key ≥ undefined
```

### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
