### PR TITLE
Release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [v2.1.0](https://github.com/auth0/node-jwks-rsa/tree/v2.1.0) (2022-04-26)
+[Full Changelog](https://github.com/auth0/node-jwks-rsa/compare/v2.0.5...v2.1.0)
+
+**Added**
+- add support for express-jwt@7 [\#297](https://github.com/auth0/node-jwks-rsa/pull/297) ([jfromaniello](https://github.com/jfromaniello))
+
+**Fixed**
+- fix(type): correct the wrong type of the `getSigningKey` function arg… [\#289](https://github.com/auth0/node-jwks-rsa/pull/289) ([stegano](https://github.com/stegano))
+
 ## [v2.0.5](https://github.com/auth0/node-jwks-rsa/tree/v2.0.5) (2021-10-15)
 [Full Changelog](https://github.com/auth0/node-jwks-rsa/compare/v2.0.4...v2.0.5)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jwks-rsa",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jwks-rsa",
-      "version": "2.0.5",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@types/express-jwt": "0.0.42",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwks-rsa",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "description": "Library to retrieve RSA public keys from a JWKS endpoint",
   "main": "src/index.js",
   "files": [


### PR DESCRIPTION

**Added**
- add support for express-jwt@7 [\#297](https://github.com/auth0/node-jwks-rsa/pull/297) ([jfromaniello](https://github.com/jfromaniello))

**Fixed**
- fix(type): correct the wrong type of the `getSigningKey` function arg… [\#289](https://github.com/auth0/node-jwks-rsa/pull/289) ([stegano](https://github.com/stegano))
