### PR TITLE
Fix issue with ES Express import

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import { Agent as HttpAgent } from 'http';
 import { Agent as HttpsAgent } from 'https';
 import type {Jwt, Secret} from 'jsonwebtoken'
-import Express from 'express'
+import Express = require('express')
 
 declare function JwksRsa(options: JwksRsa.Options): JwksRsa.JwksClient;
 
@@ -60,7 +60,7 @@ declare namespace JwksRsa {
    * Types are duplicated from express-jwt@6/7
    * due to numerous breaking changes in the lib's types
    * whilst this lib supportd both <=6 & >=7  implementations
-   * 
+   *
    * express-jwt's installed version (or its @types)
    * will be the types used at transpilation time
    */


### PR DESCRIPTION
### Description

Use `import = require()` syntax to import a CommonJS style `export =` type from @types/express

### References

fixes #309 
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/express/index.d.ts
https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require

### Testing

I'd like to remove the `esModuleInterop` flag from https://github.com/auth0/node-jwks-rsa/blob/master/tsconfig.json#L16 so our CI tests would verify this, but I can't because out `express-jwt` dependencies require this. So tested manually with basic TS config.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
