### PR TITLE
Type definitions depend on jsonwebtoken

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/express": "^4.17.13",
+        "@types/jsonwebtoken": "^8.5.8",
         "debug": "^4.3.4",
         "jose": "^2.0.5",
         "limiter": "^1.1.5",
@@ -18,7 +19,6 @@
       "devDependencies": {
         "@types/chai": "^4.2.11",
         "@types/express-jwt": "^6.0.4",
-        "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/nock": "^11.0.0",
         "@types/node": "^14.14.12",
@@ -726,7 +726,6 @@
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
       "integrity": "sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -6022,7 +6021,6 @@
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
       "integrity": "sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@types/express": "^4.17.13",
+    "@types/jsonwebtoken": "^8.5.8",
     "debug": "^4.3.4",
     "jose": "^2.0.5",
     "limiter": "^1.1.5",
@@ -21,7 +22,6 @@
   "devDependencies": {
     "@types/chai": "^4.2.11",
     "@types/express-jwt": "^6.0.4",
-    "@types/jsonwebtoken": "^8.5.8",
     "@types/mocha": "^5.2.7",
     "@types/nock": "^11.0.0",
     "@types/node": "^14.14.12",


### PR DESCRIPTION
### Description

The ts def file depends on `jsonwebtoken` so the type deps should be included in the `dependencies` (like `express`)

### References

fixes #312 
