### PR TITLE
Release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v2.2.0](https://github.com/auth0/node-jwks-rsa/tree/v2.2.0) (2022-11-01)
+[Full Changelog](https://github.com/auth0/node-jwks-rsa/compare/v2.1.5...v2.2.0)
+
+**⚠️ BREAKING CHANGES**
+- Bump jose which drops support for Node 12/10 (Security support for these versions ended 6 months and 18 months ago respectively) [\#333](https://github.com/auth0/node-jwks-rsa/pull/333) ([panva](https://github.com/panva))
+
 ## [v2.1.5](https://github.com/auth0/node-jwks-rsa/tree/v2.1.5) (2022-10-10)
 [Full Changelog](https://github.com/auth0/node-jwks-rsa/compare/v2.1.4...v2.1.5)
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Using [npm](https://npmjs.org) in your project directory run the following comma
 npm install --save jwks-rsa
 ````
 
+This library supports all LTS versions of Node.js.
+> **Note:** dropping support for End-of-Life versions of Node will not be considered breaking changes and may be done in a minor release.  
+
 Supports all currently registered JWK types and JWS Algorithms, see [panva/jose#262](https://github.com/panva/jose/issues/262) for more information.
 
 ### Configure the client

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jwks-rsa",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jwks-rsa",
-      "version": "2.1.5",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@types/express": "^4.17.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwks-rsa",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "description": "Library to retrieve RSA public keys from a JWKS endpoint",
   "main": "src/index.js",
   "files": [
@@ -9,7 +9,7 @@
   ],
   "types": "index.d.ts",
   "engines": {
-    "node": ">=10 < 13 || >=14"
+    "node": ">=14"
   },
   "dependencies": {
     "@types/express": "^4.17.14",


### PR DESCRIPTION
**⚠️ BREAKING CHANGES**
- Bump jose which drops support for Node 12/10 (Security support for these versions ended 6 months and 18 months ago respectively) [\#333](https://github.com/auth0/node-jwks-rsa/pull/333) ([panva](https://github.com/panva))
