### PR TITLE
Release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [v3.0.0](https://github.com/auth0/node-jwks-rsa/tree/v3.0.0) (2022-11-01)
+[Full Changelog](https://github.com/auth0/node-jwks-rsa/compare/v2.1.5...v3.0.0)
+
+**⚠️ BREAKING CHANGES**
+
+This release drops support for Node 10 and 12
+- [major] bump jose [\#333](https://github.com/auth0/node-jwks-rsa/pull/333) ([panva](https://github.com/panva))
+
 ## [v2.1.5](https://github.com/auth0/node-jwks-rsa/tree/v2.1.5) (2022-10-10)
 [Full Changelog](https://github.com/auth0/node-jwks-rsa/compare/v2.1.4...v2.1.5)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jwks-rsa",
-  "version": "2.1.5",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jwks-rsa",
-      "version": "2.1.5",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/express": "^4.17.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwks-rsa",
-  "version": "2.1.5",
+  "version": "3.0.0",
   "description": "Library to retrieve RSA public keys from a JWKS endpoint",
   "main": "src/index.js",
   "files": [
@@ -9,7 +9,7 @@
   ],
   "types": "index.d.ts",
   "engines": {
-    "node": ">=10 < 13 || >=14"
+    "node": ">=14"
   },
   "dependencies": {
     "@types/express": "^4.17.14",


### PR DESCRIPTION
**⚠️ BREAKING CHANGES**

This release drops support for Node 10 and 12
- [major] bump jose [\#333](https://github.com/auth0/node-jwks-rsa/pull/333) ([panva](https://github.com/panva))
