### PR TITLE
fix resolve bun/deno compat issues

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,38 @@
 const jose = require('jose');
-const crypto = require('crypto');
+const JwksError = require('./errors/JwksError');
+
+function resolveAlg(jwk) {
+  if (jwk.alg) {
+    return jwk.alg;
+  }
+
+  if (jwk.kty === 'RSA') {
+    return 'RS256';
+  }
+
+  if (jwk.kty === 'EC') {
+    switch (jwk.crv) {
+      case 'P-256':
+        return 'ES256';
+      case 'secp256k1':
+        return 'ES256K';
+      case 'P-384':
+        return 'ES384';
+      case 'P-521':
+        return 'ES512';
+    }
+  }
+
+  if (jwk.kty === 'OKP') {
+    switch (jwk.crv) {
+      case 'Ed25519':
+      case 'Ed448':
+        return 'EdDSA';
+    }
+  }
+
+  throw new JwksError('Unsupported JWK');
+}
 
 async function retrieveSigningKeys(jwks) {
   const results = [];
@@ -10,14 +43,23 @@ async function retrieveSigningKeys(jwks) {
 
   for (const jwk of jwks) {
     try {
-      // The algorithm is actually not used in the Node.js KeyObject-based runtime
-      // passing an arbitrary value here and checking that KeyObject was returned
-      // later
-      const keyObject = await jose.importJWK(jwk, 'RS256');
-      if (!(keyObject instanceof crypto.KeyObject) || keyObject.type !== 'public') {
+      const key = await jose.importJWK(jwk, resolveAlg(jwk));
+      if (key.type !== 'public') {
         continue;
       }
-      const getSpki = () => keyObject.export({ format: 'pem', type: 'spki' });
+      let getSpki;
+      switch (key[Symbol.toStringTag]) {
+        case 'CryptoKey': {
+          const spki = await jose.exportSPKI(key);
+          getSpki = () => spki;
+          break;
+        }
+        case 'KeyObject':
+          // Assume legacy Node.js version without the Symbol.toStringTag backported
+          // Fall through
+        default:
+          getSpki = () => key.export({ format: 'pem', type: 'spki' });
+      }
       results.push({
         get publicKey() { return getSpki(); },
         get rsaPublicKey() { return getSpki(); },


### PR DESCRIPTION
### Description

Since compatibility modes are becoming more and more popular it is inevitable that jwks-rsa is used in bun/deno sooner or later (actually, already might be). Because of how these runtimes fail to recognize CJS and treat its require calls to use the dependency's require package.json target we can't depend on using a node-runtime ignored algorithm argument and have to provide an actual value.

### References

- https://github.com/panva/jose/issues/579
- https://twitter.com/_panva/status/1705104713874563567

### Testing

This only stands to improve non-officially supported runtimes for this module, it does not affect how the module behaves under node.js runtime