### PR TITLE
[Fix] Change type of unused req param to unknown to resolve type conflicts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -67,11 +67,11 @@ declare namespace JwksRsa {
 
   /** Types from express-jwt@<=6 */
   type secretType = string|Buffer;
-  type SecretCallbackLong = (req: Express.Request, header: any, payload: any, done: (err: any, secret?: secretType) => void) => void;
-  type SecretCallback = (req: Express.Request, payload: any, done: (err: any, secret?: secretType) => void) => void;
+  type SecretCallbackLong = (req: unknown, header: any, payload: any, done: (err: any, secret?: secretType) => void) => void;
+  type SecretCallback = (req: unknown, payload: any, done: (err: any, secret?: secretType) => void) => void;
 
   /** Types from express-jwt@>=7 */
-  type GetVerificationKey = (req: Express.Request, token: Jwt | undefined) => Secret | undefined | Promise<Secret | undefined>;
+  type GetVerificationKey = (req: unknown, token: Jwt | undefined) => Secret | undefined | Promise<Secret | undefined>;
 
   function expressJwtSecret(options: ExpressJwtOptions): SecretCallbackLong|GetVerificationKey;
 


### PR DESCRIPTION
### Description

This PR resolves #393 by relaxing the type requirements around the `req` parameter in the callbacks returned by both the `expressJwtSecret` and `passportJwtSecret` integrations. This parameter is not used by the implementations of either function, so it can be safely relaxed to an `unknown` type. This would allow any value to be inputted, maintaining both backwards and forwards compatibility with type changes in the related express and passport libraries.

The alternative proposed in the issue would be to resolve this new conflict by updating the type to stay precisely in step with passport, but that would introduce unnecessary backwards-compatibility problems for people who were on earlier versions of `@types/passport`. Since this type's only purpose is to maintain conformance with the external library's types, going with the most permissive solution seems best.

### References

- [Passport change causing the issue](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67897/files#diff-b71c8d6ec401ffed807cc36d147e6eda88a0a5eb1a17175172ce9004026d8b79R38-L41)
- [Issue raised in this repo](https://github.com/auth0/node-jwks-rsa/issues/393)
- [Incoming major rewrite with potential to cause further disruption](https://github.com/mikenicholson/passport-jwt/pull/238)

### Testing

This change is only to make the typescript typing more permissive, and so I believe no change to the testing plan is required.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch (I think so, I'm using the default branch?)
