### PR TITLE
fix: express-jwt types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -73,7 +73,7 @@ declare namespace JwksRsa {
   /** Types from express-jwt@>=7 */
   type GetVerificationKey = (req: Express.Request, token: Jwt | undefined) => Secret | undefined | Promise<Secret | undefined>;
 
-  function expressJwtSecret(options: ExpressJwtOptions): SecretCallbackLong|GetVerificationKey;
+  function expressJwtSecret(options: ExpressJwtOptions): SecretCallbackLong & GetVerificationKey;
 
   function passportJwtSecret(options: ExpressJwtOptions): SecretCallback;
 


### PR DESCRIPTION
### Description

This is the correct type given that the returned callback can handle both configuration of arguments.

### References
This is a mistake I made in https://github.com/auth0/node-jwks-rsa/pull/297 and will definitely help with the situation at https://github.com/auth0/express-jwt/issues/288

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
