### PR TITLE
fix: prevent possible slow resolution of rate limiter

### DIFF
--- a/src/wrappers/rateLimit.js
+++ b/src/wrappers/rateLimit.js
@@ -9,26 +9,14 @@ function rateLimitWrapper(client, { jwksRequestsPerMinute = 10 }) {
   const limiter = new RateLimiter(jwksRequestsPerMinute, 'minute', true);
   logger(`Configured rate limiting to JWKS endpoint at ${jwksRequestsPerMinute}/minute`);
 
-  return async (kid) => await new Promise((resolve, reject) => {
-    limiter.removeTokens(1, async (err, remaining) => {
-      if (err) {
-        reject(err);
-      }
-
-      logger('Requests to the JWKS endpoint available for the next minute:', remaining);
-      if (remaining < 0) {
-        logger('Too many requests to the JWKS endpoint');
-        reject(new JwksRateLimitError('Too many requests to the JWKS endpoint'));
-      } else {
-        try {
-          const key = await getSigningKey(kid);
-          resolve(key);
-        } catch (error) {
-          reject(error);
-        }
-      }
-    });
-  });
+  return async (kid) => {
+    logger('Requests to the JWKS endpoint available for the next minute:', limiter.getTokensRemaining());
+    if (limiter.tryRemoveTokens(1)) {
+      return getSigningKey(kid);
+    }
+    logger('Too many requests to the JWKS endpoint');
+    throw new JwksRateLimitError('Too many requests to the JWKS endpoint');
+  };
 }
 
 module.exports.default = rateLimitWrapper;


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

We have found scenarios at scale where our requests lock up for 10+ seconds and wait for something in the rate limiter while resolving a jwk endpoint. 
We believe the intention is for the rate limiter to return immediately and not pause to wait for available tokens (hence passing the fireImmediately arg to the RateLimiter constructor).

However, maybe because of a race condition at scale (unfortunately we can't reproduce this locally), it seems possible to end up trying to resolve a token from the bucket even when there are no tokens left: 
https://github.com/jhurliman/node-rate-limiter/blob/main/src/RateLimiter.ts#L83 
Once we are on this path the rate limiter can trigger a wait for new 'tokens' become available: 
https://github.com/jhurliman/node-rate-limiter/blob/main/src/TokenBucket.ts#L96

This fix uses the simpler `tryRemoveTokens` method which synchronously returns a boolean if tokens could be taken (and so can't pause execution to wait for tokens to be available).

Although we can't write a specific test for this, the new code seems simpler and passes the existing rate-limit tests, so it seems like a good change anyway.

### Testing

There are existing tests to cover this.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
