### PR TITLE
docs: add breaking-change note for require(esm) and Jest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 **⚠️ BREAKING CHANGES**
 - Drops support for Node 14, 16, and 18. The minimum supported Node versions are now 20.19.0, 22.12.0, and 23.0.0.
 - Drops support for the ES256K algorithm (secp256k1 curve). Keys using ES256K will be ignored. Users must transition to a supported curve (e.g., ES256/P-256) or handle legacy keys externally.
-- This library relies on Node's native `require(esm)` support. Non-standard module runtimes such as **Jest** (which uses `vm.Script` instead of Node's native loader) cannot load ESM dependencies and will throw `SyntaxError: Unexpected token 'export'`. To work around this, either configure Jest to run in ESM mode via `NODE_OPTIONS=--experimental-vm-modules`, use `transformIgnorePatterns` to transpile `jose` via Babel, or mock the module in tests. See [#493](https://github.com/auth0/node-jwks-rsa/issues/493).
+- Relies on Node's native `require(esm)` support - [Loading ECMAScript modules using require()](https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require). Non-standard module runtimes such as **Jest** (uses `vm.Script`) that do not support this feature may fail while loading ESM. See [#493](https://github.com/auth0/node-jwks-rsa/issues/493) for details.
 - feat: upgrade jose dependency to v6 [\#486](https://github.com/auth0/node-jwks-rsa/pull/486) ([cschetan77](https://github.com/cschetan77))
 - chore: upgrade minimum Node.js runtime to 20.19.0 [\#485](https://github.com/auth0/node-jwks-rsa/pull/485) ([cschetan77](https://github.com/cschetan77))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 **⚠️ BREAKING CHANGES**
 - Drops support for Node 14, 16, and 18. The minimum supported Node versions are now 20.19.0, 22.12.0, and 23.0.0.
 - Drops support for the ES256K algorithm (secp256k1 curve). Keys using ES256K will be ignored. Users must transition to a supported curve (e.g., ES256/P-256) or handle legacy keys externally.
+- This library relies on Node's native `require(esm)` support. Non-standard module runtimes such as **Jest** (which uses `vm.Script` instead of Node's native loader) cannot load ESM dependencies and will throw `SyntaxError: Unexpected token 'export'`. To work around this, either configure Jest to run in ESM mode via `NODE_OPTIONS=--experimental-vm-modules`, use `transformIgnorePatterns` to transpile `jose` via Babel, or mock the module in tests. See [#493](https://github.com/auth0/node-jwks-rsa/issues/493).
 - feat: upgrade jose dependency to v6 [\#486](https://github.com/auth0/node-jwks-rsa/pull/486) ([cschetan77](https://github.com/cschetan77))
 - chore: upgrade minimum Node.js runtime to 20.19.0 [\#485](https://github.com/auth0/node-jwks-rsa/pull/485) ([cschetan77](https://github.com/cschetan77))
 


### PR DESCRIPTION
## Description
This PR improves the CHANGELOG documentation for v4.0.0 to clearly communicate the ESM compatibility limitation introduced by the `jose v6` upgrade. It clarifies that non-standard module runtimes like Jest which use their own module loaders cannot load ESM dependencies.

## Changelog Details
The breaking change now explicitly documents:
   - The dependency on Node's native `require(esm)` support
   - That Jest and similar runtimes using `vm.Script` does not support this feature
   - Reference to issue #493 for users seeking more details and potential solutions

##  Impact
Users on v4.0.0+ using Jest or other non-standard runtimes will see clear documentation of the limitation and can reference issue #493 for workarounds.

## References
   - Issue #493: ESM compatibility with Jest
   - PR #486: jose v6 upgrade that introduced this limitation