### PR TITLE
fix(release): exclude ts-output from 1.12.5 tarball

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ src/
 examples/
 coverage/
 lib-cov/
+ts-output/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.12.5] - (2026-04-29)
+
+**Fixed**
+- Exclude generated `ts-output/` files from the npm tarball
+
 ## [1.12.4] - (2026-04-17)
 
 **Security**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwks-rsa",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "description": "Library to retrieve RSA public keys from a JWKS endpoint",
   "main": "lib/index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
BillionClaw traced the 1.12.4 package contents and found that `.npmignore` was still allowing `ts-output/` into the npm tarball. I added `ts-output/` to the ignore list and bumped the maintenance release to 1.12.5. Verified with `npm pack --json --ignore-scripts`, which no longer includes `ts-output/`. Fixes #500.
