### PR TITLE
feat: add `followRedirects` option to follow 30x responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ const jwksClient = require('jwks-rsa');
 const client = jwksClient({
   jwksUri: 'https://sandrino.auth0.com/.well-known/jwks.json',
   requestHeaders: {}, // Optional
-  timeout: 30000 // Defaults to 30s
+  timeout: 30000, // Defaults to 30s
+  followRedirects: false // Follow 30x redirects, defaults to false
 });
 ````
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,7 @@ declare namespace JwksRsa {
     requestHeaders?: Headers;
     timeout?: number;
     requestAgent?: HttpAgent | HttpsAgent;
+    followRedirects?: boolean;
     getKeysInterceptor?(): Promise<JSONWebKey[]>;
   }
 

--- a/src/JwksClient.js
+++ b/src/JwksClient.js
@@ -10,6 +10,7 @@ class JwksClient {
       rateLimit: false,
       cache: true,
       timeout: 30000,
+      followRedirects: false,
       ...options
     };
 
@@ -37,7 +38,8 @@ class JwksClient {
         headers: this.options.requestHeaders,
         agent: this.options.requestAgent,
         timeout: this.options.timeout,
-        fetcher: this.options.fetcher
+        fetcher: this.options.fetcher,
+        followRedirects: this.options.followRedirects
       });
 
       logger('Keys:', res.keys);

--- a/src/wrappers/request.js
+++ b/src/wrappers/request.js
@@ -2,53 +2,71 @@ const http = require('http');
 const https = require('https');
 const ArgumentError = require('../errors/ArgumentError');
 
+const MAX_REDIRECTS = 10;
+
 module.exports.default =  (options) => {
   if (options.fetcher) {
     return options.fetcher(options.uri);
   }
 
   return new Promise((resolve, reject) => {
-    let url;
-    try {
-      url = new URL(options.uri);
-    } catch (err) {
-      throw new ArgumentError('Invalid JWKS URI: The provided URI is not a valid URL.');
-    }
-    const { hostname, port, protocol, pathname, search } = url;
-    const path = pathname + search;
+    const makeRequest = (uri, redirectCount) => {
+      let url;
+      try {
+        url = new URL(uri);
+      } catch (err) {
+        return reject(new ArgumentError('Invalid JWKS URI: The provided URI is not a valid URL.'));
+      }
+      const { hostname, port, protocol, pathname, search } = url;
+      const path = pathname + search;
 
-    const requestOptions = {
-      hostname,
-      path,
-      port,
-      method: 'GET',
-      ...(options.headers && { headers: { ...options.headers } }),
-      ...(options.timeout && { timeout: options.timeout }),
-      ...(options.agent && { agent: options.agent })
+      const requestOptions = {
+        hostname,
+        path,
+        port,
+        method: 'GET',
+        ...(options.headers && { headers: { ...options.headers } }),
+        ...(options.timeout && { timeout: options.timeout }),
+        ...(options.agent && { agent: options.agent })
+      };
+
+      const httpRequestLib = protocol === 'https:' ? https : http;
+      const httpRequest = httpRequestLib.request(requestOptions, (res) => {
+        if (options.followRedirects && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          // Discard the body of the redirect response to free up the socket.
+          res.resume();
+
+          if (redirectCount >= MAX_REDIRECTS) {
+            return reject({ errorMsg: `Maximum number of redirects (${MAX_REDIRECTS}) exceeded` });
+          }
+
+          // Resolve the location against the current url to support relative redirects.
+          return makeRequest(new URL(res.headers.location, url).toString(), redirectCount + 1);
+        }
+
+        let rawData = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => { rawData += chunk; });
+        res.on('end', () => {
+          if (res.statusCode < 200 || res.statusCode >= 300) {
+            const errorMsg = res.body && (res.body.message || res.body) || res.statusMessage || `Http Error ${res.statusCode}`;
+            reject({ errorMsg });
+          } else {
+            try {
+              resolve(rawData && JSON.parse(rawData));
+            } catch (error) {
+              reject(error);
+            }
+          }
+        });
+      });
+
+      httpRequest
+        .on('timeout', () => httpRequest.destroy())
+        .on('error', (e) => reject(e))
+        .end();
     };
 
-    const httpRequestLib = protocol === 'https:' ? https : http;
-    const httpRequest = httpRequestLib.request(requestOptions, (res) => {
-      let rawData = '';
-      res.setEncoding('utf8');
-      res.on('data', (chunk) => { rawData += chunk; });
-      res.on('end', () => {
-        if (res.statusCode < 200 || res.statusCode >= 300) {
-          const errorMsg = res.body && (res.body.message || res.body) || res.statusMessage || `Http Error ${res.statusCode}`;
-          reject({ errorMsg });
-        } else {
-          try {
-            resolve(rawData && JSON.parse(rawData));
-          } catch (error) {
-            reject(error);
-          }
-        }
-      });
-    });
-
-    httpRequest
-      .on('timeout', () => httpRequest.destroy())
-      .on('error', (e) => reject(e))
-      .end();
+    makeRequest(options.uri, 0);
   });
 };

--- a/tests/request.tests.js
+++ b/tests/request.tests.js
@@ -115,6 +115,71 @@ describe('Request wrapper tests', () => {
     request({ uri, agent });
   });
 
+  describe('when followRedirects is enabled', () => {
+    const redirectHost = 'http://my-redirect-server';
+    const redirectUri = `${redirectHost}/.well-known/jwks.json`;
+
+    it('should follow a 30x redirect and resolve the final response', (done) => {
+      nock(jwksHost)
+        .get('/.well-known/jwks.json')
+        .reply(302, undefined, { Location: redirectUri });
+      nock(redirectHost)
+        .get('/.well-known/jwks.json')
+        .reply(200, jwksJson);
+
+      request({ uri, followRedirects: true })
+        .then((data) => {
+          expect(data).to.deep.equal(jwksJson);
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should follow a relative redirect', (done) => {
+      nock(jwksHost)
+        .get('/.well-known/jwks.json')
+        .reply(301, undefined, { Location: '/keys' });
+      nock(jwksHost)
+        .get('/keys')
+        .reply(200, jwksJson);
+
+      request({ uri, followRedirects: true })
+        .then((data) => {
+          expect(data).to.deep.equal(jwksJson);
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should not follow a redirect when followRedirects is not enabled', (done) => {
+      nock(jwksHost)
+        .get('/.well-known/jwks.json')
+        .reply(302, undefined, { Location: redirectUri });
+
+      request({ uri })
+        .then(() => done('Should have thrown error'))
+        .catch((err) => {
+          expect(err.errorMsg).to.exist;
+          done();
+        });
+    });
+
+    it('should reject when the maximum number of redirects is exceeded', (done) => {
+      nock(jwksHost)
+        .persist()
+        .get('/.well-known/jwks.json')
+        .reply(302, undefined, { Location: uri });
+
+      request({ uri, followRedirects: true })
+        .then(() => done('Should have thrown error'))
+        .catch((err) => {
+          expect(err.errorMsg).to.match(/Maximum number of redirects/);
+          nock.cleanAll();
+          done();
+        });
+    });
+  });
+
   describe('when fetcher is specified', () => {
     it('should use the specified fetcher to make the request', (done) => {
       request({ 


### PR DESCRIPTION
### Description

Adds a `followRedirects` client option (default `false`) that, when enabled, follows 3xx redirect responses from the JWKS endpoint instead of treating them as errors.

Previously any 3xx status fell through the `statusCode < 200 || statusCode >= 300` check in the request wrapper and was rejected as an HTTP error. With `followRedirects: true`, the wrapper now follows the `Location` header to the final response.

### Changes

- **`src/wrappers/request.js`** — refactored the request into a recursive `makeRequest(uri, redirectCount)` helper. On a 3xx response with a `Location` header (and `followRedirects` enabled) it drains the redirect body, resolves the location against the current URL (so **both absolute and relative redirects** work), and re-issues the request reusing the same headers / timeout / agent. The chain is capped at 10 hops to guard against redirect loops.
- **`src/JwksClient.js`** — added `followRedirects: false` to the default options and threaded it through to the `request()` call in `getKeys()`.
- **`index.d.ts`** — added `followRedirects?: boolean` to `OptionsBase`.
- **`README.md`** — documented the new option.
- **`tests/request.tests.js`** — added coverage for: following an absolute 30x redirect, following a relative redirect, not following when disabled, and the max-redirects guard.

### Behavior / compatibility

Default is `false`, so existing behavior is unchanged — a 3xx still surfaces as an error unless the option is opted into.

### Testing

- `npm run lint` — clean
- `npm test` — 94 JS tests passing (incl. 4 new redirect tests) + 3 TS tests passing
