### PR TITLE
fix: load jose lazily from commonjs entrypoints

### DIFF
--- a/src/integrations/passport.js
+++ b/src/integrations/passport.js
@@ -1,6 +1,6 @@
-const jose = require('jose');
 const { ArgumentError } = require('../errors');
 const { JwksClient } = require('../JwksClient');
+const { getJose } = require('../jose');
 const supportedAlg = require('./config');
 
 const handleSigningKeyError = (err, cb) => {
@@ -28,25 +28,30 @@ module.exports.passportJwtSecret = function (options) {
   const onError = options.handleSigningKeyError || handleSigningKeyError;
 
   return function secretProvider(req, rawJwtToken, cb) {
-    let decoded;
-    try {
-      decoded = {
-        payload: jose.decodeJwt(rawJwtToken),
-        header: jose.decodeProtectedHeader(rawJwtToken)
-      };
-    } catch (err) {
-      decoded = null;
-    }
+    getJose()
+      .then(jose => {
+        let decoded;
+        try {
+          decoded = {
+            payload: jose.decodeJwt(rawJwtToken),
+            header: jose.decodeProtectedHeader(rawJwtToken)
+          };
+        } catch (err) {
+          decoded = null;
+        }
 
-    if (!decoded || !supportedAlg.includes(decoded.header.alg)) {
-      return cb(null, null);
-    }
+        if (!decoded || !supportedAlg.includes(decoded.header.alg)) {
+          return cb(null, null);
+        }
 
-    client.getSigningKey(decoded.header.kid)
-      .then(key => {
-        cb(null, key.publicKey || key.rsaPublicKey);
+        client.getSigningKey(decoded.header.kid)
+          .then(key => {
+            cb(null, key.publicKey || key.rsaPublicKey);
+          }).catch(err => {
+            onError(err, (newError) => cb(newError, null));
+          });
       }).catch(err => {
-        onError(err, (newError) => cb(newError, null));
+        cb(err, null);
       });
   };
 };

--- a/src/jose.js
+++ b/src/jose.js
@@ -1,0 +1,14 @@
+let jose;
+const dynamicImport = new Function('specifier', 'return import(specifier)');
+
+function getJose() {
+  if (!jose) {
+    jose = dynamicImport('jose');
+  }
+
+  return jose;
+}
+
+module.exports = {
+  getJose
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-const jose = require('jose');
+const { getJose } = require('./jose');
 const JwksError = require('./errors/JwksError');
 
 function resolveAlg(jwk) {
@@ -33,6 +33,7 @@ function resolveAlg(jwk) {
 }
 
 async function retrieveSigningKeys(jwks) {
+  const jose = await getJose();
   const results = [];
 
   jwks = jwks

--- a/tests/module-load.tests.js
+++ b/tests/module-load.tests.js
@@ -1,0 +1,19 @@
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+describe('CommonJS module loading', () => {
+  it('loads public entrypoints when synchronous ESM require is disabled', () => {
+    execFileSync(
+      process.execPath,
+      [
+        '--no-experimental-require-module',
+        '-e',
+        "require('./src'); require('./src/utils');"
+      ],
+      {
+        cwd: path.join(__dirname, '..'),
+        stdio: 'pipe'
+      }
+    );
+  });
+});


### PR DESCRIPTION
Fixes #507.

Summary:
- Load `jose` lazily so CommonJS entrypoints can be required without synchronously loading an ES module.
- Share the lazy loader from the utility and passport integration paths.
- Add regression coverage for requiring the public CommonJS entrypoints with synchronous ESM loading disabled.

Testing:
- `node --no-experimental-require-module -e "require('./src'); console.log('loaded top-level')"`
- `node --no-experimental-require-module -e "require('./src/utils'); console.log('loaded utils')"`
- `npm run test:js -- --grep "CommonJS module loading|utils - retrieveSigningKeys|passportJwtSecret"`
- `npm run lint`
- `npm run test:js`
- `npm test`
