### PR TITLE
chore: group codeql-action dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    groups:
+      codeql:
+        patterns:
+          - 'github/codeql-action*'


### PR DESCRIPTION
## Summary

- Groups all `github/codeql-action/*` Dependabot updates (`init`, `autobuild`, `analyze`) so they are always bumped together in a single PR

## Why

These are sub-actions of the same repository and share the same version — bumping them independently can cause version mismatches in workflows. Grouping ensures they stay in sync.

## Test plan

- [ ] Verify `.github/dependabot.yml` is valid YAML
- [ ] Confirm next Dependabot run for `github-actions` produces grouped PRs for `codeql-action`